### PR TITLE
Allow URL hash with leading integer

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -325,6 +325,14 @@ var _ = $.extend(Mavo, {
 	},
 
 	/**
+	 * Get the element identified by the URL hash
+	 */
+	getTarget: function() {
+		var id = location.hash.substr(1);
+		return document.getElementById(id);
+	},
+
+	/**
 	 * Object utilities
 	 */
 
@@ -620,12 +628,12 @@ document.addEventListener("blur", evt => {
 }, true);
 
 addEventListener("hashchange", evt => {
-	updateWithin("target", $(location.hash));
+	updateWithin("target", _.getTarget());
 });
 
 document.documentElement.addEventListener("mavo:datachange", evt => {
 	// TODO debounce
-	updateWithin("target", $(location.hash));
+	updateWithin("target", _.getTarget());
 });
 
 updateWithin("focus", document.activeElement !== document.body? document.activeElement : null);


### PR DESCRIPTION
Fixes #220, in which using a hash URL starting with an integer would trigger an error.

The extra function might be overkill, but it seemed nicer than having `document.getElementById(location.hash.substr(1))` twice in a row.
