### PR TITLE
Add missing stub for put on backend

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -49,6 +49,7 @@ var _ = Mavo.Backend = $.Class({
 	ready: Promise.resolve(),
 	login: () => Promise.resolve(),
 	logout: () => Promise.resolve(),
+	put: () => Promise.resolve(),
 
 	isAuthenticated: function() {
 		return !!this.accessToken;


### PR DESCRIPTION
`this.put` is called from `store`, but it didn't have a stub yet so fails now with `this.put is not a function`.

Alternatively, I can implement `put` with a rejected promise, or implement it as `HTTP PUT` (analogous to how `get` implements `GET`).