### PR TITLE
allow line breaks in js expressions

### DIFF
--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -333,7 +333,7 @@ var _ = Mavo.Script = {
 
 		return new Function("data", `with(Mavo.Functions._Trap)
 				with (data || {}) {
-					return ${code};
+					return (${code});
 				}`);
 	},
 


### PR DESCRIPTION
Allow line breaks in js mode expressions by enclosing in parens.
fixes #307 