### PR TITLE
Fix bug that skips second if-statement in ordinal function

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -266,7 +266,7 @@ var _ = Mavo.Functions = {
 			return "";
 		}
 
-		if (ord < 10 || ord > 20) {
+		if (num < 10 || num > 20) {
 			var ord = ["th", "st", "nd", "th"][num % 10];
 		}
 


### PR DESCRIPTION
Stumbled across a bug in `ordinal()` while documenting missing Mavo functions.