### PR TITLE
Use searchParam.set to populate req.data

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -102,7 +102,7 @@ var _ = Mavo.Backend = $.Class({
 				for (const p in req.data) {
 					call.searchParams.set(p, req.data[p]);
 				}
-				req.data = "";
+				delete req.data;
 			}
 			else {
 				req.data = JSON.stringify(req.data);

--- a/src/backend.js
+++ b/src/backend.js
@@ -99,9 +99,11 @@ var _ = Mavo.Backend = $.Class({
 
 		if ($.type(req.data) === "object") {
 			if (req.method == "GET") {
-				Object.keys(req.data).map(p => call.searchParams.set(p, req.data[p]));
 				req.data = call.search;
 				call.search = "";
+				for (const p in req.data) {
+					call.searchParams.set(p, req.data[p]);
+				}
 			}
 			else {
 				req.data = JSON.stringify(req.data);

--- a/src/backend.js
+++ b/src/backend.js
@@ -89,26 +89,24 @@ var _ = Mavo.Backend = $.Class({
 		}
 
 		req.data = data;
-		var dataParam;
+
+		call = new URL(call, this.constructor.apiDomain);
 
 		// Prevent getting a cached response. Cache-control is often not allowed via CORS
 		if (req.method == "GET") {
-			dataParam = new URL("https://mavo.io");
-			dataParam.searchParams.set("timestamp", Date.now());
+			call.searchParams.set("timestamp", Date.now());
 		}
 
 		if ($.type(req.data) === "object") {
 			if (req.method == "GET") {
-				Object.keys(req.data).map(p => dataParam.searchParams.set(p, req.data[p]));
+				Object.keys(req.data).map(p => call.searchParams.set(p, req.data[p]));
+				req.data = call.search;
+				call.search = "";
 			}
 			else {
 				req.data = JSON.stringify(req.data);
 			}
 		}
-
-		req.data = dataParam ? dataParam.search : req.data;
-
-		call = new URL(call, this.constructor.apiDomain);
 
 		return $.fetch(call, req)
 			.catch(err => {

--- a/src/backend.js
+++ b/src/backend.js
@@ -99,11 +99,10 @@ var _ = Mavo.Backend = $.Class({
 
 		if ($.type(req.data) === "object") {
 			if (req.method == "GET") {
-				req.data = call.search;
-				call.search = "";
 				for (const p in req.data) {
 					call.searchParams.set(p, req.data[p]);
 				}
+				req.data = "";
 			}
 			else {
 				req.data = JSON.stringify(req.data);


### PR DESCRIPTION
This is the **new PR** after recreating the branch from master. Below are my old comments:

Now, instead of setting the timestamp on the variable`call`, if the request method is `GET`, all the `searchParams` are set on `req.data`. My question is it going to make any difference now `timestamp` is set in `req.data`?

Also, I noticed that the workaround I proposed (concatenating `"&"` with the data params) is only used when the method is GET and timestamp is only set when the method is GET. So shouldn't the workaround always work?