### PR TITLE
Improve handling of empty expressions

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -102,7 +102,8 @@ _.Syntax = $.Class({
 
 			if (/\S/.test(match[1])) {
 				ret.push(new Mavo.Expression(match[1]));
-			} else {
+			}
+			else {
 				// If the matched expression is empty or consists only of
 				// whitespace, don't treat it as an expression.
 				ret.push(match[0]);

--- a/src/expression.js
+++ b/src/expression.js
@@ -70,7 +70,15 @@ _.Syntax = $.Class({
 	constructor: function(start, end) {
 		this.start = start;
 		this.end = end;
-		this.regex = RegExp(`${Mavo.escapeRegExp(start)}([\\S\\s]+?)${Mavo.escapeRegExp(end)}`, "gi");
+		// Try to parse anything between start and end as an expression. Note
+		// that this parses text that we don't want to treat as expressions,
+		// including the empty expression, but we want to parse them out anyway
+		// and only later decide not to evaluate them as expressions so that we
+		// don't parse, say, [][1] as a single expression containing "][1".
+
+		// Regex note: "[\S\s]" matches all characters, unlike ".", which
+		// doesn't match newlines.
+		this.regex = RegExp(`${Mavo.escapeRegExp(start)}([\\S\\s]*?)${Mavo.escapeRegExp(end)}`, "gi");
 	},
 
 	test: function(str) {
@@ -92,7 +100,13 @@ _.Syntax = $.Class({
 
 			lastIndex = this.regex.lastIndex;
 
-			ret.push(new Mavo.Expression(match[1]));
+			if (/\S/.test(match[1])) {
+				ret.push(new Mavo.Expression(match[1]));
+			} else {
+				// If the matched expression is empty or consists only of
+				// whitespace, don't treat it as an expression.
+				ret.push(match[0]);
+			}
 		}
 
 		// Literal at the end

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -585,6 +585,14 @@ var _ = Mavo.Script = {
 	},
 
 	compile: function(code, o = {}) {
+		if (!/\S/.test(code)) {
+			// If code contains only whitespace, including in particular if
+			// code is just the empty string, treat it as an expression that
+			// evaluates to an empty string. This is consistent with
+			// interpreting bare words as their corresponding strings.
+			return () => "";
+		}
+
 		code = _.rewrite(code);
 
 		code = `with (Mavo.Data.stub)


### PR DESCRIPTION
Don't treat empty expressions or expressions with only spaces as
expressions. However, still parse them out so that they don't interfere
with the next expression. If we are forced to evaluate such an
expression (e.g. via mv-value), evaluate it to the empty string.

Fixes #392.