### PR TITLE
Fix unary operation arguments

### DIFF
--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -36,10 +36,10 @@ var _ = Mavo.Script = {
 
 				for (let i = 0; i < max; i++) {
 					if (a[i] === undefined) {
-						result[i] = rightUnary ? rightUnary(a[i]) : o.scalar(leftDefault, b[i]);
+						result[i] = rightUnary ? rightUnary(b[i]) : o.scalar(leftDefault, b[i]);
 					}
 					else if (b[i] === undefined) {
-						result[i] = leftUnary ? leftUnary(b[i]) : o.scalar(a[i], rightDefault);
+						result[i] = leftUnary ? leftUnary(a[i]) : o.scalar(a[i], rightDefault);
 					}
 					else {
 						result[i] = o.scalar(a[i], b[i]);


### PR DESCRIPTION
Found a tiny bug left from [PR#375](https://github.com/mavoweb/mavo/pull/375).

This will make `divide()` and `and()` work properly. 