### PR TITLE
Add "rd" option to ordinal function

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -263,7 +263,7 @@ var _ = Mavo.Functions = {
 		}
 
 		if (num < 10 || num > 20) {
-			var ord = ["th", "st", "nd", "th"][num % 10];
+			var ord = ["th", "st", "nd", "rd", "th"][num % 10];
 		}
 
 		return ord || "th";


### PR DESCRIPTION
I noticed that `ordinal(3)` returns `th` instead of `rd`, so I added the option to the function.