### PR TITLE
Binary Operation: Allow parameter of type Function as argument

### DIFF
--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -23,6 +23,7 @@ var _ = Mavo.Script = {
 	},
 
 	binaryOperation: function(a, b, o = {}) {
+		o.scalar = typeof o === "function" ? o : o.scalar;
 		var result;
 
 		if (Array.isArray(b)) {


### PR DESCRIPTION
This feature is to support #374. When wrapping a function with `binaryOperation()`, one can pass the function with metadata as `o`. `o.scalar` is then assigned from `o`, and the function's metadata such as `unary` and `default` will be automatically assigned too.