### PR TITLE
track observer instance in mavo mv-load event handler fixes #413

### DIFF
--- a/src/mavo.js
+++ b/src/mavo.js
@@ -223,9 +223,9 @@ var _ = self.Mavo = $.Class({
 							});
 						}
 
-						if (observer) {
-							observer.destroy();
-							observer = null;
+						if (this.observer) {
+							this.observer.destroy();
+							this.observer = null;
 						}
 					}
 
@@ -234,7 +234,7 @@ var _ = self.Mavo = $.Class({
 
 				if (!callback()) {
 					// No target, perhaps not yet?
-					var observer = new Mavo.Observer(this.element, "id", callback, {subtree: true});
+					this.observer = new Mavo.Observer(this.element, "id", callback, {subtree: true});
 				}
 			}
 


### PR DESCRIPTION
track this observer instance to remove it manually when necessary. otherwise the observer instance will stay in memory, keep reference to mavo and node instances, and prevent destroyed nodes from garbage collection.