### PR TITLE
use Map instead of WeakMap for Mavo.elementData fixes #417

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -263,7 +263,7 @@ var _ = Mavo.Functions = {
 		}
 
 		if (num < 10 || num > 20) {
-			var ord = ["th", "st", "nd", "th"][num % 10];
+			var ord = ["th", "st", "nd", "rd", "th"][num % 10];
 		}
 
 		return ord || "th";

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -23,6 +23,7 @@ var _ = Mavo.Script = {
 	},
 
 	binaryOperation: function(a, b, o = {}) {
+		o.scalar = typeof o === "function" ? o : o.scalar;
 		var result;
 
 		if (Array.isArray(b)) {

--- a/src/primitive.js
+++ b/src/primitive.js
@@ -461,7 +461,7 @@ var _ = Mavo.Primitive = $.Class({
 						// FIXME Once this is resolved with mousedown, every time we edit, evt is still mousedown regardless
 						// so this ends up focusing even when it shouldn't
 						if (evt && evt.type == "mousedown" || document.activeElement === this.element) {
-							this.editor.focus();
+							requestAnimationFrame(() => this.editor.focus());
 						}
 
 						if (!this.collection) {

--- a/src/util.js
+++ b/src/util.js
@@ -195,7 +195,7 @@ var _ = $.extend(Mavo, {
 		return ret;
 	},
 
-	elementData: new WeakMap(),
+	elementData: new Map(),
 
 	/**
 	 * Get node from path or get path of a node to an ancestor


### PR DESCRIPTION
As documented in issue #417 , WeakMap is ineffective in managing circular references. It prevents manual management as by design it does not allow iteration. A data structure of Map is more suitable in this case. Please consider.