### PR TITLE
clear timeout callback upon dismiss message fixes #420

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -263,7 +263,7 @@ var _ = Mavo.Functions = {
 		}
 
 		if (num < 10 || num > 20) {
-			var ord = ["th", "st", "nd", "th"][num % 10];
+			var ord = ["th", "st", "nd", "rd", "th"][num % 10];
 		}
 
 		return ord || "th";

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -23,6 +23,7 @@ var _ = Mavo.Script = {
 	},
 
 	binaryOperation: function(a, b, o = {}) {
+		o.scalar = typeof o === "function" ? o : o.scalar;
 		var result;
 
 		if (Array.isArray(b)) {

--- a/src/primitive.js
+++ b/src/primitive.js
@@ -461,7 +461,7 @@ var _ = Mavo.Primitive = $.Class({
 						// FIXME Once this is resolved with mousedown, every time we edit, evt is still mousedown regardless
 						// so this ends up focusing even when it shouldn't
 						if (evt && evt.type == "mousedown" || document.activeElement === this.element) {
-							this.editor.focus();
+							requestAnimationFrame(() => this.editor.focus());
 						}
 
 						if (!this.collection) {

--- a/src/ui.message.js
+++ b/src/ui.message.js
@@ -58,11 +58,10 @@ var _ = Mavo.UI.Message = $.Class({
 
 		if (o.dismiss.timeout) {
 			var timeout = typeof o.dismiss.timeout === "number"? o.dismiss.timeout : 5000;
-			var closeTimeout;
-
+			
 			$.bind(this.element, {
-				mouseenter: e => clearTimeout(closeTimeout),
-				mouseleave: Mavo.rr(e => closeTimeout = setTimeout(() => this.close(), timeout)),
+				mouseenter: e => clearTimeout(this.closeTimeout),
+				mouseleave: Mavo.rr(e => this.closeTimeout = setTimeout(() => this.close(), timeout)),
 			});
 		}
 
@@ -75,6 +74,9 @@ var _ = Mavo.UI.Message = $.Class({
 	},
 
 	close: function(resolve) {
+		// clearTimeout, make the callback available for garbage collection, and make it easier to debug memory issues
+		// it does nothing if there is no timeout callback.
+		clearTimeout(this.closeTimeout);
 		var duration = this.element.style.transition ? 1000 * parseFloat(window.getComputedStyle(this.element, null).transitionDuration) : 400;
 		$.transition(this.element, {opacity: 0}, duration)
 		.then(() => {


### PR DESCRIPTION
The context of timeout callback contains reference to the message object and Mavo instance. The function is invoked 20 seconds later, and is easily overlooked when recording memory allocation timeline to debug memory related issues. The details of the rationale behind this PR is documented in issue #420. Please consider.