### PR TITLE
fresh - make the defined property of Mavo.all configurable

### DIFF
--- a/src/mavo.js
+++ b/src/mavo.js
@@ -17,7 +17,7 @@ var _ = self.Mavo = $.Class({
 
 		// Index among other mavos in the page, 1 is first
 		this.index = Object.keys(_.all).length + 1;
-		Object.defineProperty(_.all, this.index - 1, {value: this});
+		Object.defineProperty(_.all, this.index - 1, {value: this, configurable: true});
 
 		// Convert any data-mv-* attributes to mv-*
 		var selector = _.attributes.map(attribute => `[data-${attribute}]`).join(", ");


### PR DESCRIPTION
This is a PR based on a fresh checkout from mavoweb/mavo master branch.

As requested in issue #410, there are use cases to activate Mavo manually and destroy instances when done. This makes it much faster to load/render a page with multiple Mavo apps not activated yet, and activate/deactivate apps dynamically on demand. With this approach we can avoid the spike of memory consumption when loading the page, and run the apps even on older smart phones.

Currently the defined property of Mavo.all holds immutable reference to created instances, and prevents Mavo instances from garbage collection. Making the defined property configurable empowers Mavo to play a key role in larger apps. Please consider this change,