### PR TITLE
fresh - clear dismiss timeout on close fixes #420

### DIFF
--- a/src/ui.message.js
+++ b/src/ui.message.js
@@ -58,11 +58,10 @@ var _ = Mavo.UI.Message = $.Class({
 
 		if (o.dismiss.timeout) {
 			var timeout = typeof o.dismiss.timeout === "number"? o.dismiss.timeout : 5000;
-			var closeTimeout;
 
 			$.bind(this.element, {
-				mouseenter: e => clearTimeout(closeTimeout),
-				mouseleave: Mavo.rr(e => closeTimeout = setTimeout(() => this.close(), timeout)),
+				mouseenter: e => clearTimeout(this.closeTimeout),
+				mouseleave: Mavo.rr(e => this.closeTimeout = setTimeout(() => this.close(), timeout)),
 			});
 		}
 
@@ -75,6 +74,9 @@ var _ = Mavo.UI.Message = $.Class({
 	},
 
 	close: function(resolve) {
+		// clearTimeout, make the callback available for garbage collection, and make it easier to debug memory issues
+		// it does nothing if there is no timeout callback.
+		clearTimeout(this.closeTimeout);
 		var duration = this.element.style.transition ? 1000 * parseFloat(window.getComputedStyle(this.element, null).transitionDuration) : 400;
 		$.transition(this.element, {opacity: 0}, duration)
 		.then(() => {


### PR DESCRIPTION
This PR is based on a fresh checkout of the master branch from mavoweb/mavo.

The context of timeout callback contains reference to the message object and Mavo instance. The function is invoked 20 seconds later, and is easily overlooked when recording memory allocation timeline to debug memory related issues. The details of the rationale behind this PR is documented in issue #420. Please consider.