### PR TITLE
fresh - WIP: use Map instead of WeakMap for Mavo.elementData fixes #417

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -195,7 +195,7 @@ var _ = $.extend(Mavo, {
 		return ret;
 	},
 
-	elementData: new WeakMap(),
+	elementData: new Map(),
 
 	/**
 	 * Get node from path or get path of a node to an ancestor


### PR DESCRIPTION
This is a PR based on fresh checkout of the master branch from mavoweb/mavo.

As documented in issue #417 , WeakMap is ineffective in managing circular references. It prevents manual management as by design it does not allow iteration. A data structure of Map is more suitable in this case. Please consider.