### PR TITLE
skip setting loading attribute at init stage if instance exists

### DIFF
--- a/src/mavo.js
+++ b/src/mavo.js
@@ -853,7 +853,7 @@ requestAnimationFrame(() => {
 	);
 
 	_.inited = $.ready().then(() => {
-		$.attributes($$(_.selectors.init), {"mv-progress": "Loading"});
+		//$.attributes($$(_.selectors.init), {"mv-progress": "Loading"});
 		return _.ready;
 	})
 	.catch(console.error)

--- a/src/mavo.js
+++ b/src/mavo.js
@@ -853,7 +853,12 @@ requestAnimationFrame(() => {
 	);
 
 	_.inited = $.ready().then(() => {
-		//$.attributes($$(_.selectors.init), {"mv-progress": "Loading"});
+		$$(_.selectors.init).forEach(function(elem) {
+			// skip if an instance has been created, for example by another script.
+			if (!Mavo.get(elem)) {
+				elem.setAttribute("mv-progress", "Loading");
+			}
+		});
 		return _.ready;
 	})
 	.catch(console.error)


### PR DESCRIPTION
Upon page load, when some apps are activated manually but asynchronously using a Promise, the manual activation could happen before or after the main activation script(also a Promise) runs. If the manual activation happens first, the main activation script resets the status to loading, finds nothing to activate, exits, but leaves the status as loading. The apps function normally otherwise but the loading indicator is always shown. End users may think this is a bug, as if the loading never finishes.

This issue is very difficult to solve using a plugin or hook as the main app flow won't call it if the apps have already been activated. Hence this PR for delaying the ui update in init script. please consider. 

The status will be set later by individual functions.
