### PR TITLE
empty node id from array upon delete fixes #426

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -132,7 +132,7 @@ var _ = Mavo.Node = $.Class({
 			this.itembar.destroy();
 		}
 
-		_.all[this.uid] = null;
+		delete _.all[this.uid];
 	},
 
 	getData: function(o = {}) {


### PR DESCRIPTION
as discussed, empty the position in array held by a node upon deleting the node, but still keep the array length.