### PR TITLE
destroy originalEditorObserver in primitive when done

### DIFF
--- a/src/primitive.js
+++ b/src/primitive.js
@@ -196,6 +196,7 @@ var _ = Mavo.Primitive = $.Class({
 
 		this.defaultObserver && this.defaultObserver.destroy();
 		this.observer && this.observer.destroy();
+		this.originalEditorObserver && this.originalEditorObserver.destroy();
 	},
 
 	isDataNull: function(o) {


### PR DESCRIPTION
with reference to discussions on issue #417, disconnect and destroy originalEditorObserver in primitive when done to release resources. 