### PR TITLE
prevent infinite recursion when registering domexpression (fix #434)

### DIFF
--- a/src/expressions.js
+++ b/src/expressions.js
@@ -24,7 +24,7 @@ var _ = Mavo.Expressions = $.Class({
 
 	register: function(domexpression) {
 		var ids = this.identifiers;
-
+		domexpression.registeredApp = domexpression.registeredApp || new Set();
 		domexpression.identifiers.forEach(id => {
 			if (!(ids[id] instanceof Set)) {
 				ids[id] = new Set();
@@ -32,8 +32,9 @@ var _ = Mavo.Expressions = $.Class({
 
 			ids[id].add(domexpression);
 
-			if (Mavo.all[id] instanceof Mavo && Mavo.all[id] !== this.mavo) {
-				// Cross-mavo expressions
+			if (Mavo.all[id] instanceof Mavo && Mavo.all[id] !== this.mavo && !domexpression.registeredApp.has(id) ) {
+				// Cross-mavo expressions, make sure to track app id before calling register.
+				domexpression.registeredApp.add(id);
 				Mavo.all[id].expressions.register(domexpression);
 			}
 		});


### PR DESCRIPTION
This PR tracks Mavo app ids and checks whether a Mavo app has already registered a domexpression instance before registering it again. This makes sure each app will register a domexpression once only, and prevents infinite recursion when an expression involves multiple external apps.