### PR TITLE
make sure domexpression exists before unregister recursively fixes #436

### DIFF
--- a/src/expressions.js
+++ b/src/expressions.js
@@ -48,7 +48,7 @@ var _ = Mavo.Expressions = $.Class({
 			}
 			// just in case domexpresssion has been destroyed by another app during the loop
 			// when another app is destroyed.
-			if (id in Mavo.all && 'object' == typeof domexpresssion && domexpresssion) {
+			if (id in Mavo.all && 'undefined' !== typeof domexpresssion) {
 				// Cross-mavo expressions
 				Mavo.all[id].expressions.unregister(domexpresssion);
 			}

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -48,7 +48,7 @@ var _ = Mavo.Expressions = $.Class({
 			}
 			// just in case domexpresssion has been destroyed by another app during the loop
 			// when another app is destroyed.
-			if (id in Mavo.all && 'undefined' !== typeof domexpresssion) {
+			if (id in Mavo.all && typeof domexpresssion !== "undefined") {
 				// Cross-mavo expressions
 				Mavo.all[id].expressions.unregister(domexpresssion);
 			}

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -46,8 +46,9 @@ var _ = Mavo.Expressions = $.Class({
 			if (ids[id]) {
 				ids[id].delete(this);
 			}
-
-			if (id in Mavo.all) {
+			// just in case domexpresssion has been destroyed by another app during the loop
+			// when another app is destroyed.
+			if (id in Mavo.all && 'object' == typeof domexpresssion && domexpresssion) {
 				// Cross-mavo expressions
 				Mavo.all[id].expressions.unregister(domexpresssion);
 			}


### PR DESCRIPTION
When an expression involves multiple external apps, domexpression could have been destroyed during the loop when another app is destroyed. This PR makes sure domexpression still exists before calling  an external app's `expressions.unregister()` function, and thus avoids Uncaught ReferenceError thrown by browsers.