### PR TITLE
Fix MavoScript operator precedences

### DIFF
--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -191,7 +191,7 @@ var _ = Mavo.Script = {
 				return ret;
 			},
 			symbol: "mod",
-			precedence: 6
+			precedence: 10
 		},
 		"lte": {
 			comparison: true,
@@ -236,13 +236,14 @@ var _ = Mavo.Script = {
 			},
 			symbol: ["=", "=="],
 			default: true,
-			precedence: 6
+			precedence: 7 // to match other comparison operators in jsep
 		},
 		"neq": {
 			comparison: true,
 			scalar: (a, b) => a != b,
 			symbol: ["!="],
-			default: true
+			default: true,
+			precedence: 7 // to match other comparison operators in jsep
 		},
 		"and": {
 			scalar: (a, b) => a && b,


### PR DESCRIPTION
Make `==` and `!=` the same precedence as the comparison operators, so
that they chain properly.

Also make `mod` the same precedence as `*` `/` and `%`, which I think is
the only sensible precedence for it; it might have been an error
introduced in babf794e79b66dfef947af97e0732c4856ee8518.