### PR TITLE
Make neq the actual inverse of eq

### DIFF
--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -240,7 +240,9 @@ var _ = Mavo.Script = {
 		},
 		"neq": {
 			comparison: true,
-			scalar: (a, b) => a != b,
+			scalar: (a, b) => {
+				return a != b && Mavo.safeToJSON(a) !== Mavo.safeToJSON(b);
+			},
 			symbol: ["!="],
 			default: true,
 			precedence: 7 // to match other comparison operators in jsep


### PR DESCRIPTION
The old version seems to have many false positives as we usually compare
proxies for data or objects, and JavaScript doesn't do any coercion
beyond checking that they're distinct pointers in memory.