### PR TITLE
Check for unprefixed special properties to listen to

### DIFF
--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -247,8 +247,11 @@ var _ = Mavo.DOMExpression = $.Class({
 			add: function(domexpression, name) {
 				if (name) {
 					var o = this.vars[name];
+					var hasName = domexpression.identifiers.indexOf(name) > -1;
+					var hasUnprefixedName = (name.startsWith("$") &&
+						domexpression.identifiers.indexOf(name.substr(1)) > -1);
 
-					if (o && domexpression.identifiers.indexOf(name) > -1) {
+					if (o && (hasName || hasUnprefixedName)) {
 						o.all = o.all || new Set();
 						o.all.add(domexpression);
 


### PR DESCRIPTION
Fixes #348. The downside is that an unnecessary listener that does
nothing will be added if a Mavo user has a property called (e.g.)
`mouse` and references it, but this seems a small price to pay.