### PR TITLE
Make most comparisons return undefined on one undefined operand

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -570,7 +570,7 @@ function str(str = "") {
 
 function empty(v) {
 	v = Mavo.value(v);
-	return v === null || v === false || v === "";
+	return v === undefined || v === null || v === false || v === "";
 }
 
 function not(v) {

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -37,7 +37,7 @@ var _ = Mavo.Script = {
 
 				for (let i = 0; i < max; i++) {
 					if (o.comparison && (a[i] === undefined || b[i] === undefined)) {
-						result[i] = true;
+						result[i] = o.default ? true : undefined;
 					}
 					else if (a[i] === undefined) {
 						result[i] = rightUnary ? rightUnary(b[i]) : o.scalar(leftDefault, b[i]);
@@ -96,7 +96,7 @@ var _ = Mavo.Script = {
 				operands = operands.map(val);
 			}
 
-			var prev = o.comparison ? o.default : operands[0], result;
+			var prev = o.comparison ? true : operands[0], result;
 
 			for (let i = 1; i < operands.length; i++) {
 				let a = o.comparison? operands[i - 1] : prev;
@@ -211,7 +211,7 @@ var _ = Mavo.Script = {
 				[a, b] = _.getNumericalOperands(a, b);
 				return a <= b;
 			},
-			default: true,
+			default: false,
 			symbol: "<="
 		},
 		"lt": {
@@ -220,7 +220,7 @@ var _ = Mavo.Script = {
 				[a, b] = _.getNumericalOperands(a, b);
 				return a < b;
 			},
-			default: true,
+			default: false,
 			symbol: "<"
 		},
 		"gte": {
@@ -229,7 +229,7 @@ var _ = Mavo.Script = {
 				[a, b] = _.getNumericalOperands(a, b);
 				return a >= b;
 			},
-			default: true,
+			default: false,
 			symbol: ">="
 		},
 		"gt": {
@@ -238,7 +238,7 @@ var _ = Mavo.Script = {
 				[a, b] = _.getNumericalOperands(a, b);
 				return a > b;
 			},
-			default: true,
+			default: false,
 			symbol: ">"
 		},
 		"eq": {
@@ -247,7 +247,7 @@ var _ = Mavo.Script = {
 				return a == b || Mavo.safeToJSON(a) === Mavo.safeToJSON(b);
 			},
 			symbol: ["=", "=="],
-			default: true,
+			default: false,
 			precedence: 7 // to match other comparison operators in jsep
 		},
 		"neq": {
@@ -260,7 +260,15 @@ var _ = Mavo.Script = {
 			precedence: 7 // to match other comparison operators in jsep
 		},
 		"and": {
-			scalar: (a, b) => a && b,
+			scalar: (a, b) => {
+				if (a === undefined || b === undefined) {
+					// This doesn't affect the truth value of the result, but
+					// we think we want false && undefined to be undefined
+					// because undefined is "stronger"
+					return undefined;
+				}
+				return a && b;
+			},
 			default: false,
 			symbol: ["&&", "and"],
 			precedence: 2


### PR DESCRIPTION
Uses the "default" property to mean the result of the comparison when
one element is undefined. Also make the "empty" function say that
undefined is falsy. Fixes #404.

(The amount of changes to handle `undefined` is a little large for my tastes. Also I see that `empty` tested for `null` before this PR. Does Mavo use `null` right now? I think we definitely do not want to handle both `null` and `undefined` in Mavo.)