### PR TITLE
Bug: contains function

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -445,38 +445,34 @@ var _ = Mavo.Functions = {
 	}),
 
 	/**
-     * Search if a group, collection, or primitive contains needle
-	 * @returns Boolean if a haystack of object or primitive is passed
-	 * @returns Array of booleans if a haystack of array is passed
-     */
-    contains: (haystack, needle) => {
-		var ret = Mavo.Script.binaryOperation(haystack, needle, {
-			scalar: (haystack, needle) => {
-				if ($.type(haystack) === "object") {
-					for (var property in haystack) {
-						ret = _.contains(haystack[property], needle);
-						if (Array.isArray(ret)) {
-							ret = Mavo.Functions.or(ret);
-						}
-						if (ret) {
-							return true;
-						}
-					}
-				}
-				else {
-					return _.search(haystack, needle) >= 0;
-				}
-				return ret;
-			},
-		});
+	 * Search if a group, collection, or primitive contains a string
+	 * @returns Boolean if a haystack AND needle of object or primitive are passed
+	 * @returns Array of booleans if either a haystack OR needle of array is passed
+	 */
+	contains: $.extend((haystack, needle) => {
+		let result;
+		let haystackType = $.type(haystack);
 
-		// if result is an empty array, return false
-		if (ret.length === 0) {
-			return false;
+		if (haystackType === "object" || haystackType === "array") {
+			for (let property in haystack) {
+				result = _.contains(haystack[property], needle);
+
+				if (Array.isArray(result)) {
+					result = Mavo.Functions.or(result);
+				}
+				if (result) {
+					return true;
+				}
+			}
+		}
+		else {
+			return _.search(haystack, needle) >= 0;
 		}
 
-		return ret;
-    },
+		return result;
+	}, {
+		multiValued: true
+	}),
 
 	/**
 	 * Case insensitive search
@@ -666,7 +662,7 @@ var _ = Mavo.Functions = {
 					var ret = callback.call(this, ...arguments);
 
 					return ret === undefined? array : ret;
-				}
+				};
 			}
 
 			if (newCallback) {

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -695,7 +695,7 @@ var _ = Mavo.Script = {
 
 					if (def && def.needsContext) {
 						// Why not function.call(...)? Because it's a more drastic change.
-						node.arguments.unshift({type: "Identifier", name: "$this"})
+						node.arguments.unshift({type: "Identifier", name: "$this"});
 					}
 				}
 			}


### PR DESCRIPTION
Addressed some issues after converting `search()` function with `binaryOperation()`. All tests pass except:

1. The ones where the needle is an object. Do you think it'll be a good idea to enable the function to check if a haystack contains a specified object?
2. An edge case where either the haystack or needle is `[]`. Instead of defaulting to `false`, the function will return `[]` because when `binaryOperation` is called, the arguments won't be processed by the scalar since `[].length = 0`. This seems rather ungraceful to me, especially in the case of `contains` and `search` where it's quite likely that Mavo apps will search an empty list and the developer will expect the function to return `[false]`. Perhaps in `binaryOperations` I could check if this edge case appears, do `scalar(leftDefault, rightDefault)`?