### PR TITLE
Add .mv-no-hiding-during-loading class

### DIFF
--- a/src-css/mavo.scss
+++ b/src-css/mavo.scss
@@ -234,7 +234,7 @@ button.mv-close {
 	}
 }
 
-[mv-progress="Loading"] [mv-multiple] {
+[mv-progress="Loading"]:not(.mv-no-hiding-during-loading) [mv-multiple] {
 	display: none;
 }
 


### PR DESCRIPTION
Add a class that can be used to suppress the hiding of mv-multiple
elements when loading. Useful for the upcoming server-side rendering.