### PR TITLE
Feat/haystack contains object

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -453,6 +453,10 @@ var _ = Mavo.Functions = {
 		let result;
 		let haystackType = $.type(haystack);
 
+		if ($.type(needle) === "object") {
+			return JSON.stringify(haystack).indexOf(JSON.stringify(needle)) >= 0;
+		}
+
 		if (haystackType === "object" || haystackType === "array") {
 			for (let property in haystack) {
 				result = _.contains(haystack[property], needle);
@@ -469,7 +473,7 @@ var _ = Mavo.Functions = {
 			return _.search(haystack, needle) >= 0;
 		}
 
-		return result;
+		return ret;
 	}, {
 		multiValued: true
 	}),

--- a/src/functions.js
+++ b/src/functions.js
@@ -450,7 +450,7 @@ var _ = Mavo.Functions = {
 	 * @returns Array of booleans if either a haystack OR needle of array is passed
 	 */
 	contains: $.extend((haystack, needle) => {
-		let result;
+		let ret;
 		let haystackType = $.type(haystack);
 
 		if ($.type(needle) === "object") {
@@ -459,12 +459,12 @@ var _ = Mavo.Functions = {
 
 		if (haystackType === "object" || haystackType === "array") {
 			for (let property in haystack) {
-				result = _.contains(haystack[property], needle);
+				ret = _.contains(haystack[property], needle);
 
-				if (Array.isArray(result)) {
-					result = Mavo.Functions.or(result);
+				if (Array.isArray(ret)) {
+					ret = Mavo.Functions.or(ret);
 				}
-				if (result) {
+				if (ret) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Search for the needle of type `object` *very* strictly, w/o ignoring the order of properties. It'd be a good start though. I could add additional features later.

This PR fixes the first two current failed tests. We may want to discuss w/ David about the last edge case test. Some of Lea's initial thoughts can be found in PR #510.