### PR TITLE
Add the minified version of the Mavo CSS file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 dist/*.js
 dist/*.css
 local.js
+.DS_Store

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -113,8 +113,10 @@ gulp.task("minify-es5", function () {
 
 gulp.task("minify-css", function () {
 	return gulp.src("dist/mavo.css")
+		.pipe(sourcemaps.init())
 		.pipe(csso())
 		.pipe(concat("mavo.min.css"))
+		.pipe(sourcemaps.write("maps"))
 		.pipe(gulp.dest("dist"));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ var sourcemaps = require("gulp-sourcemaps");
 var notify = require("gulp-notify");
 var merge = require("merge2");
 var injectVersion = require("gulp-inject-version");
-var csso = require('gulp-csso');
+var csso = require("gulp-csso");
 
 var dependencies = ["../../bliss/bliss.shy.min.js", "../../stretchy/stretchy.min.js", "../../jsep/build/jsep.min.js"];
 var src = `mavo util locale locale.en plugins ui.bar ui.message permissions backend formats

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ var sourcemaps = require("gulp-sourcemaps");
 var notify = require("gulp-notify");
 var merge = require("merge2");
 var injectVersion = require("gulp-inject-version");
+var csso = require('gulp-csso');
 
 var dependencies = ["../../bliss/bliss.shy.min.js", "../../stretchy/stretchy.min.js", "../../jsep/build/jsep.min.js"];
 var src = `mavo util locale locale.en plugins ui.bar ui.message permissions backend formats
@@ -110,6 +111,13 @@ gulp.task("minify-es5", function () {
 		.pipe(gulp.dest("dist"));
 });
 
+gulp.task("minify-css", function () {
+	return gulp.src("dist/mavo.css")
+		.pipe(csso())
+		.pipe(concat("mavo.min.css"))
+		.pipe(gulp.dest("dist"));
+});
+
 gulp.task("lib", function () {
 	return gulp.src(dependencies).pipe(gulp.dest("lib"));
 });
@@ -121,4 +129,4 @@ gulp.task("watch", function () {
 	gulp.watch(["**/*.scss"], gulp.series("sass"));
 });
 
-gulp.task("default", gulp.parallel(gulp.series("concat", gulp.parallel("transpile", "minify", "minify-es5")), "sass"));
+gulp.task("default", gulp.parallel(gulp.series("concat", gulp.parallel("transpile", "minify", "minify-es5")), gulp.series("sass", "minify-css")));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mavo",
-  "version": "0.1.7-beta",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3160,7 +3160,8 @@
         },
         "lodash": {
           "version": "4.17.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "loose-envify": {
@@ -3820,6 +3821,25 @@
         }
       }
     },
+    "css-tree": {
+      "version": "1.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+      "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+      "dev": true,
+      "requires": {
+        "mdn-data": "~1.1.0",
+        "source-map": "^0.5.3"
+      }
+    },
+    "csso": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+      "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+      "dev": true,
+      "requires": {
+        "css-tree": "1.0.0-alpha.29"
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -4447,7 +4467,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4468,12 +4489,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4488,17 +4511,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4615,7 +4641,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4627,6 +4654,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4641,6 +4669,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4648,12 +4677,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4672,6 +4703,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4759,7 +4791,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4771,6 +4804,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4856,7 +4890,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4892,6 +4927,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4911,6 +4947,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4954,12 +4991,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5393,6 +5432,69 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
+        }
+      }
+    },
+    "gulp-csso": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-csso/-/gulp-csso-3.0.1.tgz",
+      "integrity": "sha512-zhkvq06x1SJrpBN8YNJfc1PDono2+xjB6nI9UmBPh88nS4Weuz0hZMgJ4YruOw9Bf+oDrX71U6pkos6pIQhc1g==",
+      "dev": true,
+      "requires": {
+        "csso": "^3.0.0",
+        "plugin-error": "^0.1.2",
+        "vinyl-sourcemaps-apply": "^0.2.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
+          }
+        },
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+          "dev": true
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        },
+        "plugin-error": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+          "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+          "dev": true,
+          "requires": {
+            "ansi-cyan": "^0.1.1",
+            "ansi-red": "^0.1.1",
+            "arr-diff": "^1.0.1",
+            "arr-union": "^2.0.1",
+            "extend-shallow": "^1.1.2"
+          }
         }
       }
     },
@@ -6839,6 +6941,12 @@
           }
         }
       }
+    },
+    "mdn-data": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+      "dev": true
     },
     "memoizee": {
       "version": "0.4.14",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "url": "https://github.com/mavoweb/mavo/issues"
   },
   "homepage": "https://mavo.io",
-  "browserslist": ["last 4 versions", "IE 11"],
+  "browserslist": [
+    "last 4 versions",
+    "IE 11"
+  ],
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
@@ -30,6 +33,7 @@
     "gulp-babel": "^8.0.0",
     "gulp-babel-minify": "^0.5.0",
     "gulp-concat": "^2.6.0",
+    "gulp-csso": "^3.0.1",
     "gulp-inject-version": "^1.0.1",
     "gulp-notify": "^3.2.0",
     "gulp-rename": "^1.4.0",


### PR DESCRIPTION
Since Lea labeled issue #540 as a good first issue, I decided to make my first PR to close it. Hope I made it right. Ready to fix any errors I made.
Unfortunately, I don't know how to use `mavo.css` as a source, minify it and write the minified version in the same directory with another name without the `concat` plugin (I tried several ways). 😞 I didn't want to add other plugins for that.