### PR TITLE
Make <select> read-only, fixes  #559

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -217,6 +217,7 @@ _.register({
 	"select": {
 		extend: "formControl",
 		selector: "select",
+		modes: "read",
 		subtree: true
 	},
 


### PR DESCRIPTION
> ... it doesn't quite make sense to show an editing popup for <option> but primarily because it should be read-only!

If I am not mistaken, not only `<option>` should be read-only, but `<select>` itself.