### PR TITLE
Make <option> read-only, fixes 559

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -220,6 +220,12 @@ _.register({
 		subtree: true
 	},
 
+	"option": {
+		extend: "formControl",
+		selector: "option",
+		modes: "read"
+	},
+
 	"textarea": {
 		extend: "formControl",
 		selector: "textarea",


### PR DESCRIPTION
Since `<option>` extends `formControl` there is no more need to use the `mv-attribute=value` attribute to force Mavo store values in the `value` attribute when:
1) `<select>` is dynamic and its values defined by the `mv-value` attribute of `<option>`
2) and the content of `<option>` is an expression.

E.g., instead of
```javascript
...
<option mv-multiple="monthOption" mv-value="1 .. 12" mv-attribute="value">
  ['Month ' & $this]
</option>
...
```

we can simply write
```javascript
...
<option mv-multiple="monthOption" mv-value="1 .. 12">
  ['Month ' & $this]
</option>
...
```
![`option` read-only](https://user-images.githubusercontent.com/9166277/71445127-11db9600-2728-11ea-8b10-31882e55e828.png)

Hope now I am not wrong. 🤞 