### PR TITLE
Allow specifying different upload backend than storage backend

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -165,7 +165,7 @@ _.register({
 		editor: function() {
 			var kind = this.element.nodeName.toLowerCase();
 			kind = kind == "img"? "image" : kind;
-			Mavo.setAttributeShy(this.element, "mv-uploads", kind + "s");
+			Mavo.setAttributeShy(this.element, "mv-upload-path", kind + "s");
 
 			return this.createUploadPopup(kind + "/*", kind, "png");
 		}
@@ -176,7 +176,7 @@ _.register({
 		attribute: "href"
 	},
 
-	"a[mv-uploads], link[mv-uploads]": {
+	"a[mv-upload-path], link[mv-upload-path]": {
 		default: true,
 		attribute: "href",
 		editor: function() {

--- a/src/mavo.js
+++ b/src/mavo.js
@@ -85,7 +85,7 @@ var _ = self.Mavo = $.Class({
 
 		this.permissions = new Mavo.Permissions();
 
-		var backendTypes = ["source", "storage", "init"]; // order is significant!
+		var backendTypes = ["source", "storage", "init", "upload-backend"]; // order is significant!
 
 		// Figure out backends for storage, data reads, and initialization respectively
 		backendTypes.forEach(role => this.updateBackend(role));
@@ -713,7 +713,18 @@ var _ = self.Mavo = $.Class({
 		},
 
 		uploadBackend: {
-			get: function() {
+			get: function () {
+				const backend = this["upload-backend"];
+
+				if (backend && backend.upload) {
+					// We need to authenticate a user if we haven't done that earlier
+					if (backend.permissions.login) {
+						backend.login();
+					}
+						
+					return this["upload-backend"];
+				}
+
 				if (this.storage && this.storage.upload) {
 					// Prioritize storage
 					return this.storage;

--- a/src/mavo.js
+++ b/src/mavo.js
@@ -85,7 +85,7 @@ var _ = self.Mavo = $.Class({
 
 		this.permissions = new Mavo.Permissions();
 
-		var backendTypes = ["source", "storage", "init", "upload-backend"]; // order is significant!
+		var backendTypes = ["source", "storage", "init", "uploads"]; // order is significant!
 
 		// Figure out backends for storage, data reads, and initialization respectively
 		backendTypes.forEach(role => this.updateBackend(role));
@@ -714,7 +714,7 @@ var _ = self.Mavo = $.Class({
 
 		uploadBackend: {
 			get: function () {
-				const backend = this["upload-backend"];
+				const backend = this["uploads"];
 
 				if (backend && backend.upload) {
 					// We need to authenticate a user if we haven't done that earlier
@@ -722,7 +722,7 @@ var _ = self.Mavo = $.Class({
 						backend.login();
 					}
 						
-					return this["upload-backend"];
+					return this["uploads"];
 				}
 
 				if (this.storage && this.storage.upload) {

--- a/src/primitive.js
+++ b/src/primitive.js
@@ -727,7 +727,7 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 		// FIXME what if there's no attribute?
 		this.sneak(() => this.element.setAttribute(this.attribute, tempURL));
 
-		var path = this.element.getAttribute("mv-uploads") || "";
+		var path = this.element.getAttribute("mv-upload-path") || "";
 		var relative = path + "/" + name;
 
 		this.mavo.upload(file, relative).then(url => {


### PR DESCRIPTION
Let's try to close #537 and make Mavo even more powerful.

I suggested that this type of backend can be specified via the `mv-upload-backend` attribute (because `mv-uploads` and `mv-upload-url` are already taken, and `mv-upload` can confuse users).

I could miss some key points or messed something up, so I open to critique.