### PR TITLE
Improve error reporting

### DIFF
--- a/src/mavo.js
+++ b/src/mavo.js
@@ -326,8 +326,10 @@ var _ = self.Mavo = $.Class({
 		return new _.UI.Message(this, message, options);
 	},
 
-	error: function(message, ...log) {
-		this.message(message, {
+	error: function (message, ...log) {
+		// If a custom error message is provided (in an element with class mv-error),
+		// show it to an end-user (Fix for #101)
+		this.message($(".mv-error", this.element) || message, {
 			type: "error",
 			dismiss: ["button", "timeout"]
 		});

--- a/src/mavo.js
+++ b/src/mavo.js
@@ -329,7 +329,7 @@ var _ = self.Mavo = $.Class({
 	error: function (message, ...log) {
 		// If a custom error message is provided (in an element with class mv-error),
 		// show it to an end-user (Fix for #101)
-		this.message($(".mv-error", this.element) || message, {
+		this.message($(".mv-error:not(.mv-ui):not(.mv-message)", this.element) || message, {
 			type: "error",
 			dismiss: ["button", "timeout"]
 		});

--- a/src/mavo.js
+++ b/src/mavo.js
@@ -329,7 +329,16 @@ var _ = self.Mavo = $.Class({
 	error: function (message, ...log) {
 		// If a custom error message is provided (in an element with class mv-error),
 		// show it to an end-user (Fix for #101)
-		this.message($(".mv-error:not(.mv-ui):not(.mv-message)", this.element) || message, {
+		let customMessage = message;
+		const template = $(".mv-error:not(.mv-ui):not(.mv-message)", this.element);
+
+		if (template) {
+			// If a custom error message template IS an actual template element,
+			// we need to grab its content
+			customMessage = template.content || template;
+		}
+
+		this.message(customMessage, {
 			type: "error",
 			dismiss: ["button", "timeout"]
 		});


### PR DESCRIPTION
Let's try to close #101, and add to Mavo the ability to Include a custom error message template, with class `mv-error`.

I need to put into words a couple of thoughts I have to make sure I get everything correctly:

1. We can provide only one error message per app. Even though we have three potential cases when an error may occur: while loading, saving, or uploading. Should we distinguish these cases somehow?

2. We should provide a custom error template inside a `hidden` wrapper element in order not to render it on a page before we need it, like so:
```html
<div hidden>
  <div class="mv-error">
    <strong>Error!</strong> We have a problem. Check the browser console for details.
  </div>
</div>
```

Are we OK with that?