### PR TITLE
Fix for #469

### DIFF
--- a/src/ui.bar.js
+++ b/src/ui.bar.js
@@ -209,7 +209,7 @@ var _ = Mavo.UI.Bar = $.Class({
 						return keep || (!_.controls[id].optional && !drop);
 					});
 
-					ids = ids.filter(id => all.contains(id));
+					ids = ids.filter(id => all.includes(id));
 
 					ids.forEach(id => all.splice(all.indexOf(id), 1, undefined));
 					ids.forEach(id => all.splice(all.indexOf(undefined), 1, id));

--- a/src/ui.bar.js
+++ b/src/ui.bar.js
@@ -209,12 +209,7 @@ var _ = Mavo.UI.Bar = $.Class({
 						return keep || (!_.controls[id].optional && !drop);
 					});
 
-					ids = ids.filter(id => {
-						const positive = all.lastIndexOf(id);
-						const negative = all.lastIndexOf("no-" + id);
-
-						return positive > Math.max(-1, negative);
-					});
+					ids = ids.filter(id => all.contains(id));
 
 					ids.forEach(id => all.splice(all.indexOf(id), 1, undefined));
 					ids.forEach(id => all.splice(all.indexOf(undefined), 1, id));

--- a/src/ui.bar.js
+++ b/src/ui.bar.js
@@ -200,7 +200,7 @@ var _ = Mavo.UI.Bar = $.Class({
 				ids = Mavo.Functions.unique(ids.reverse()).reverse();
 
 				if (relative) {
-					return all.filter(id => {
+					all = all.filter(id => {
 						var positive = ids.lastIndexOf(id);
 						var negative = ids.lastIndexOf("no-" + id);
 						var keep = positive > Math.max(-1, negative);
@@ -208,6 +208,18 @@ var _ = Mavo.UI.Bar = $.Class({
 
 						return keep || (!_.controls[id].optional && !drop);
 					});
+
+					ids = ids.filter(id => {
+						const positive = all.lastIndexOf(id);
+						const negative = all.lastIndexOf("no-" + id);
+
+						return positive > Math.max(-1, negative);
+					});
+
+					ids.forEach(id => all.splice(all.indexOf(id), 1, undefined));
+					ids.forEach(id => all.splice(all.indexOf(undefined), 1, id));
+
+					return all;
 				}
 
 				return ids;

--- a/src/ui.bar.js
+++ b/src/ui.bar.js
@@ -200,7 +200,7 @@ var _ = Mavo.UI.Bar = $.Class({
 				ids = Mavo.Functions.unique(ids.reverse()).reverse();
 
 				if (relative) {
-					// For every control in a default set, we decide whether to drop it or not and add an extra property to it—the pos property.
+					// For every control in the default set, we decide whether to drop it or not and add an extra property to it—the pos property.
 					// Controls specified by a user have pos >= 0 (their relative position in a user's set).
 					// Not optional buttons of the default set that are not specified and not dropped have pos = -1.
 					// Then filter out not picked up optional controls (their value will be undefined)

--- a/src/ui.bar.js
+++ b/src/ui.bar.js
@@ -202,7 +202,7 @@ var _ = Mavo.UI.Bar = $.Class({
 				if (relative) {
 					// For every control in the default set, we decide whether to drop it or not and add an extra property to it—the pos property.
 					// Controls specified by a user have pos >= 0 (their relative position in a user's set).
-					// Not optional buttons of the default set that are not specified and not dropped have pos = -1.
+					// Not optional controls of the default set that are not specified and not dropped have pos = -1.
 					// Then filter out not picked up optional controls (their value will be undefined)
 					all = all.map(id => {
 						var positive = ids.lastIndexOf(id);
@@ -223,7 +223,7 @@ var _ = Mavo.UI.Bar = $.Class({
 					let pos = -1;
 
 					// Return the result set of controls: default controls not specified by a user stay untucked,
-					// specified—take their proper position
+					// specified—take their proper positions
 					return all.map(id => {
 						if (id.pos === -1) {
 							return id.name;


### PR DESCRIPTION
Retain button order in the bar when the relative syntax is used.

Added the corresponding test to the test suite.