### PR TITLE
Add more granular control for the autosave feature

### DIFF
--- a/src/mavo.js
+++ b/src/mavo.js
@@ -302,7 +302,7 @@ var _ = self.Mavo = $.Class({
 				}, this.autoSaveDelay);
 
 				var callback = evt => {
-					if (evt.node.saved) {
+					if (evt.node.saved && this.autoSave) {
 						debouncedSave();
 					}
 				};


### PR DESCRIPTION
Now we and plugin authors can disable autosave when needed.
E.g., when working with real-time data updates,
we don't want data loss from race condition
with autosave and realtime updates.