### PR TITLE
Updated duration() to include terms parameter

### DIFF
--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -117,36 +117,22 @@ _.duration = $.extend(function (ms, terms) {
 	let ret = [];
 	let units = Object.keys(s).reverse();
 	units.push("ms");
-	let unitsUsed = [];
-	let onlyConsecutiveNonzeros = true;
+	let noUnitSkipped = true;
 
-	units.map(function(unit) {
+	units.forEach(function(unit, index) {
 		// get largest value of time unit for the remaining
 		// time to account for
 		let unitValue = unit === "ms"? timeLeft : _.msTo(unit, timeLeft);
 		timeLeft -= unitValue * (unit === "ms" ? 1 : Mavo.Functions[unit]());
-		return unitValue;
-	}).forEach(function (currentValue, index) {
-		if (currentValue !== 0 && ret.length < terms) {
-			let unitProperPlurality = currentValue === 1 && units[index] !== "ms" ? units[index].slice(0, -1) : units[index];
-			ret.push(currentValue + " " + Mavo.Functions.phrase($this, unitProperPlurality));
 
-			// so we have a list of unit terms used to later determine whether they're consecutive
-			unitsUsed.push(units[index]);
-		};
-	});
-
-	ret.filter(function (currentValue, index) {
-		// terms must be consecutive
-		if (index !== 0) {
-
-			if ((units.indexOf(unitsUsed[index]) - units.indexOf(unitsUsed[index-1])) !== 1) {
-				// we will not populate the returning array further since
-				// the following units won't be consecutive
-				onlyConsecutiveNonzeros = false;
-			}
+		if (unitValue !== 0 && ret.length < terms && noUnitSkipped) {
+			let unitProperPlurality = unitValue === 1 && units[index] !== "ms" ? units[index].slice(0, -1) : units[index];
+			ret.push(unitValue + " " + Mavo.Functions.phrase(this, unitProperPlurality));
 		}
-		return onlyConsecutiveNonzeros;
+		else if (ret.length > 0) {
+			// terms are no longer consecutive terms
+			noUnitSkipped = false;
+		}
 	});
 
 	if (ret.length === 0) {

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -114,7 +114,7 @@ _.duration = $.extend(function ($this, ms, terms) {
     }
 
     if (ms===0 || terms === undefined) {
-			terms = 1;
+terms = 1;
     }
 
     let timeLeft = ms || 0;
@@ -146,8 +146,7 @@ _.duration = $.extend(function ($this, ms, terms) {
       }
 
       if (unitTime!=0 || terms === 1) {
-        let unitProperPlurality = unitTime === 1 && unit !== "ms" ?
-					unit.slice(0, -1) : unit;
+        let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
         ret.push(unitTime + " " + _.phrase($this, unitProperPlurality));
         timeLeft -= unitTime * (unit === "ms" ? 1 : Mavo.Functions[unit]());
       }
@@ -158,8 +157,7 @@ _.duration = $.extend(function ($this, ms, terms) {
       }
     }
 
-    return (arguments.length ===1 ||
-			(arguments.length ===2 && $this!== undefined))? ret[0] : ret;
+    return (arguments.length ===1 || (arguments.length ===2 && $this!== undefined))? ret[0] : ret;
 }, {
     needsContext: true
 });

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -109,57 +109,57 @@ for (let unit in s) {
 }
 
 _.duration = $.extend(function ($this, ms, terms) {
-    if (arguments.length === 1) {
-      [ms, $this] = [$this, null];
-    }
+		if (arguments.length === 1) {
+			[ms, $this] = [$this, null];
+		}
 
-    if (ms===0 || terms === undefined) {
-      terms = 1;
-    }
+		if (ms===0 || terms === undefined) {
+			terms = 1;
+		}
 
-    let timeLeft = ms || 0;
-    let ret = [];
-    let unitsToUse = ["ms"];
+		let timeLeft = ms || 0;
+		let ret = [];
+		let unitsToUse = ["ms"];
 
-    // populate unitsToUse with all the terms that can fit within timeLeft
-    // in order of lowest to highest magnitude,
+		// populate unitsToUse with all the terms that can fit within timeLeft
+		// in order of lowest to highest magnitude,
 		// so we have a list of consecutive unit terms to later reference
-    for (let nextUnit in s) {
-      let count = _.msTo(nextUnit, timeLeft);
+		for (let nextUnit in s) {
+			let count = _.msTo(nextUnit, timeLeft);
 
-      if (count === 0) {
-        break;
-      }
+			if (count === 0) {
+				break;
+			}
 
-      unitsToUse.push(nextUnit);
-    }
+			unitsToUse.push(nextUnit);
+		}
 
-    while (ret.length < terms && unitsToUse.length > 0) {
-      let unit = unitsToUse.pop();
+		while (ret.length < terms && unitsToUse.length > 0) {
+			let unit = unitsToUse.pop();
 			let unitTime;
 
-      if (unit!=="ms") {
-        unitTime = _.msTo(unit, timeLeft);
-      }
-      else {
-        unitTime = timeLeft;
-      }
+			if (unit!=="ms") {
+				unitTime = _.msTo(unit, timeLeft);
+			}
+			else {
+				unitTime = timeLeft;
+			}
 
-      if (unitTime!=0 || terms === 1) {
-        let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
-        ret.push(unitTime + " " + _.phrase($this, unitProperPlurality));
-        timeLeft -= unitTime * (unit === "ms" ? 1 : Mavo.Functions[unit]());
-      }
-      else {
-        // we will not populate the returning array further since
-        // the following units won't be consecutive
-        break;
-      }
-    }
+			if (unitTime!=0 || terms === 1) {
+				let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
+				ret.push(unitTime + " " + _.phrase($this, unitProperPlurality));
+				timeLeft -= unitTime * (unit === "ms" ? 1 : Mavo.Functions[unit]());
+			}
+			else {
+				// we will not populate the returning array further since
+				// the following units won't be consecutive
+				break;
+			}
+		}
 
-    return (arguments.length ===1 || (arguments.length ===2 && $this!== undefined))? ret[0] : ret;
+		return (arguments.length ===1 || (arguments.length ===2 && $this!== undefined))? ret[0] : ret;
 }, {
-    needsContext: true
+		needsContext: true
 });
 
 $.extend(_.util, {

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -114,7 +114,7 @@ _.duration = $.extend(function ($this, ms, terms) {
     }
 
     if (ms===0 || terms === undefined) {
-terms = 1;
+ terms = 1;
     }
 
     let timeLeft = ms || 0;
@@ -128,7 +128,7 @@ terms = 1;
       let count = _.msTo(nextUnit, timeLeft);
 
       if (count === 0) {
-				break;
+   break;
       }
 
       unitsToUse.push(nextUnit);

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -108,27 +108,32 @@ for (let unit in s) {
 	}, {multiValued: true});
 }
 
-_.duration = $.extend(function($this, ms, terms = 1) {
+_.duration = $.extend(function($this, ms, terms) {
 	if (arguments.length === 1) {
 		[ms, $this] = [$this, null];
 	}
 	
+	let wantString = terms === undefined ? true : false;
 	let unitTime = ms || 0;
 	let timeLeft = ms || 0;
 	
-	if (ms === 0) {
+	if (ms === 0 || wantString) {
 		terms = 1;
 	}
 	
-	let timeArray = [];
+	let ret = [];
 	
-	while (timeArray.length < terms && (timeLeft > 0 || terms === 1)) {
+	while (ret.length < terms && (timeLeft > 0 || terms === 1)) {
+		// Only add terms if more than 1 term was designated, and those terms must be nonzero,
+      		// else, if one term was desitnated, that term can be nonzero
 		let unit = "ms";
 		
 		for (let nextUnit in s) {
 			let count = _.msTo(nextUnit, timeLeft);
 			
 			if (count === 0) {
+				// next higher-magnitude term occurs 0 times within timeLeft,
+          			// so remain with last loop's assigned unit & unitTime
 				break;
 			}
 			
@@ -138,13 +143,18 @@ _.duration = $.extend(function($this, ms, terms = 1) {
 		
 		if (unitTime !== 0 || terms === 1) {
 			let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
-			timeArray.push(unitTime + " " + _.phrase($this, unitProperPlurality));
-			timeLeft -= unit === "ms" ? unitTime : unitTime * Mavo.Functions[unit]();
+			ret.push(unitTime + " " + _.phrase($this, unitProperPlurality));
+			timeLeft -= unitTime * (unit === "ms" ? 1 : Mavo.Functions[unit]());
 			unitTime = timeLeft;
 		}
 		
 	}
-	return timeArray;
+	
+	if (wantString) {
+      		return ret[0];
+    	}
+		
+    	return ret;
 }, {
 	needsContext: true
 });

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -127,7 +127,7 @@ _.duration = $.extend(function (ms, terms) {
 		timeLeft -= unitValue * (unit === "ms" ? 1 : Mavo.Functions[unit]());
 		return unitValue;
 	}).forEach(function (currentValue, index) {
-		if (currentValue !==0 && ret.length < terms) {
+		if (currentValue !== 0 && ret.length < terms) {
 			let unitProperPlurality = currentValue === 1 && units[index] !== "ms" ? units[index].slice(0, -1) : units[index];
 			ret.push(currentValue + " " + Mavo.Functions.phrase($this, unitProperPlurality));
 

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -114,21 +114,21 @@ _.duration = $.extend(function ($this, ms, terms) {
     }
 
     if (ms===0 || terms === undefined) {
-	terms=1;
+			terms = 1;
     }
 
     let timeLeft = ms || 0;
     let ret = [];
     let unitsToUse = ["ms"];
 
-    // want to populate unitsToUse with all the terms that can fit within timeLeft
+    // populate unitsToUse with all the terms that can fit within timeLeft
     // in order of lowest to highest magnitude,
 		// so we have a list of consecutive unit terms to later reference
     for (let nextUnit in s) {
       let count = _.msTo(nextUnit, timeLeft);
 
       if (count === 0) {
-        break;
+				break;
       }
 
       unitsToUse.push(nextUnit);
@@ -146,7 +146,8 @@ _.duration = $.extend(function ($this, ms, terms) {
       }
 
       if (unitTime!=0 || terms === 1) {
-        let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
+        let unitProperPlurality = unitTime === 1 && unit !== "ms" ?
+					unit.slice(0, -1) : unit;
         ret.push(unitTime + " " + _.phrase($this, unitProperPlurality));
         timeLeft -= unitTime * (unit === "ms" ? 1 : Mavo.Functions[unit]());
       }
@@ -157,7 +158,8 @@ _.duration = $.extend(function ($this, ms, terms) {
       }
     }
 
-    return (arguments.length ===1 ||  (arguments.length ===2 && $this!== undefined))? ret[0] : ret;
+    return (arguments.length ===1 ||
+			(arguments.length ===2 && $this!== undefined))? ret[0] : ret;
 }, {
     needsContext: true
 });

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -109,57 +109,57 @@ for (let unit in s) {
 }
 
 _.duration = $.extend(function ($this, ms, terms) {
-		if (arguments.length === 1) {
-			[ms, $this] = [$this, null];
+	if (arguments.length === 1) {
+		[ms, $this] = [$this, null];
+	}
+
+	if (ms===0 || terms === undefined) {
+		terms = 1;
+	}
+
+	let timeLeft = ms || 0;
+	let ret = [];
+	let unitsToUse = ["ms"];
+
+	// populate unitsToUse with all the terms that can fit within timeLeft
+	// in order of lowest to highest magnitude,
+	// so we have a list of consecutive unit terms to later reference
+	for (let nextUnit in s) {
+		let count = _.msTo(nextUnit, timeLeft);
+
+		if (count === 0) {
+			break;
 		}
 
-		if (ms===0 || terms === undefined) {
-			terms = 1;
+		unitsToUse.push(nextUnit);
+	}
+
+	while (ret.length < terms && unitsToUse.length > 0) {
+		let unit = unitsToUse.pop();
+		let unitTime;
+
+		if (unit!=="ms") {
+			unitTime = _.msTo(unit, timeLeft);
+		}
+		else {
+			unitTime = timeLeft;
 		}
 
-		let timeLeft = ms || 0;
-		let ret = [];
-		let unitsToUse = ["ms"];
-
-		// populate unitsToUse with all the terms that can fit within timeLeft
-		// in order of lowest to highest magnitude,
-		// so we have a list of consecutive unit terms to later reference
-		for (let nextUnit in s) {
-			let count = _.msTo(nextUnit, timeLeft);
-
-			if (count === 0) {
-				break;
-			}
-
-			unitsToUse.push(nextUnit);
+		if (unitTime!=0 || terms === 1) {
+			let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
+			ret.push(unitTime + " " + _.phrase($this, unitProperPlurality));
+			timeLeft -= unitTime * (unit === "ms" ? 1 : Mavo.Functions[unit]());
 		}
-
-		while (ret.length < terms && unitsToUse.length > 0) {
-			let unit = unitsToUse.pop();
-			let unitTime;
-
-			if (unit!=="ms") {
-				unitTime = _.msTo(unit, timeLeft);
-			}
-			else {
-				unitTime = timeLeft;
-			}
-
-			if (unitTime!=0 || terms === 1) {
-				let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
-				ret.push(unitTime + " " + _.phrase($this, unitProperPlurality));
-				timeLeft -= unitTime * (unit === "ms" ? 1 : Mavo.Functions[unit]());
-			}
-			else {
-				// we will not populate the returning array further since
-				// the following units won't be consecutive
-				break;
-			}
+		else {
+			// we will not populate the returning array further since
+			// the following units won't be consecutive
+			break;
 		}
+	}
 
-		return (arguments.length ===1 || (arguments.length ===2 && $this!== undefined))? ret[0] : ret;
+	return (arguments.length ===1 || (arguments.length ===2 && $this!== undefined))? ret[0] : ret;
 }, {
-		needsContext: true
+	needsContext: true
 });
 
 $.extend(_.util, {

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -108,7 +108,7 @@ for (let unit in s) {
 	}, {multiValued: true});
 }
 
-_.duration = $.extend(function ($this, ms, terms = 1) {
+_.duration = $.extend(function($this, ms, terms = 1) {
 	if (arguments.length === 1) {
 		[ms, $this] = [$this, null];
 	}
@@ -139,7 +139,7 @@ _.duration = $.extend(function ($this, ms, terms = 1) {
 		if (unitTime !== 0 || terms === 1) {
 			let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
 			timeArray.push(unitTime + " " + _.phrase($this, unitProperPlurality));
-			timeLeft -= unit === "ms" ? unitTime : unitTime* Mavo.Functions[unit]();
+			timeLeft -= unit === "ms" ? unitTime : unitTime * Mavo.Functions[unit]();
 			unitTime = timeLeft;
 		}
 		

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -114,7 +114,7 @@ _.duration = $.extend(function ($this, ms, terms) {
     }
 
     if (ms===0 || terms === undefined) {
- terms = 1;
+      terms = 1;
     }
 
     let timeLeft = ms || 0;
@@ -128,7 +128,7 @@ _.duration = $.extend(function ($this, ms, terms) {
       let count = _.msTo(nextUnit, timeLeft);
 
       if (count === 0) {
-   break;
+        break;
       }
 
       unitsToUse.push(nextUnit);

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -98,16 +98,6 @@ $.extend(_, {
 
 _.msTo = (what, ms) => Math.floor(Math.abs(ms) / (s[what] * 1000)) || 0;
 
-_.toMs = function (what, value) {
-    if(what==="ms") return value;
-    if(what==="seconds") return value*1000;
-    for (var nextUnit in s) {
-      if(nextUnit === what) {
-        return _.toMs("seconds", value*s[what]);
-      }
-    }
-};
-
 for (let unit in s) {
 	_[unit] = $.extend(function(ms) {
 		if (arguments.length === 0) {
@@ -118,46 +108,43 @@ for (let unit in s) {
 	}, {multiValued: true});
 }
 
-	
 _.duration = $.extend(function ($this, ms, terms = 1) {
-    if (arguments.length === 1) {
-      [ms, $this] = [$this, null];
-    }
-
-    var msFromSingleTimeUnit = ms || 0;
-    var msLeftTotal = ms || 0;
-    if (ms===0) terms=1;
-    var returnString = "";
-    var numberTermsUsed = terms;
-    while( numberTermsUsed >0 && (msLeftTotal > 0 || terms==1)) {
-      var unit = "ms";
-    
-      for (let nextUnit in s) {
-
-        var nextCount = _.msTo(nextUnit, msLeftTotal);
-
-        if (nextCount === 0) {
-        
-          break;
-
-        }
-        msFromSingleTimeUnit = nextCount;
-        unit = nextUnit;
-      }
-
-      if(msFromSingleTimeUnit!=0 || terms === 1) {
-
-        var unitWithProperPlurality = msFromSingleTimeUnit === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
-        returnString += msFromSingleTimeUnit + " " + _.phrase($this, unitWithProperPlurality)+ " ";
-        numberTermsUsed--;
-        msLeftTotal-=_.toMs(unit,msFromSingleTimeUnit);
-        msFromSingleTimeUnit = msLeftTotal;
-
-      } 
-    
-    }
-  
-    return returnString.slice(0,-1);
+	if (arguments.length === 1) {
+		[ms, $this] = [$this, null];
+	}
+	
+	let unitTime = ms || 0;
+	let timeLeft = ms || 0;
+	
+	if (ms === 0) {
+		terms = 1;
+	}
+	
+	let timeArray = [];
+	
+	while (timeArray.length < terms && (timeLeft > 0 || terms === 1)) {
+		let unit = "ms";
+		
+		for (let nextUnit in s) {
+			let count = _.msTo(nextUnit, timeLeft);
+			
+			if (count === 0) {
+				break;
+			}
+			
+			unitTime = count;
+			unit = nextUnit;
+		}
+		
+		if (unitTime !== 0 || terms === 1) {
+			let unitProperPlurality = unitTime === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
+			timeArray.push(unitTime + " " + _.phrase($this, unitProperPlurality));
+			timeLeft -= unit === "ms" ? unitTime : unitTime* Mavo.Functions[unit]();
+			unitTime = timeLeft;
+		}
+		
+	}
+	return timeArray;
 }, {
 	needsContext: true
 });

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -121,23 +121,15 @@ _.duration = $.extend(function (ms, terms) {
 	let onlyConsecutiveNonzeros = true;
 
 	units.map(function(unit) {
-		let unitValue;
-
 		// get largest value of time unit for the remaining
 		// time to account for
-		if (unit !== "ms") {
-			unitValue = _.msTo(unit, timeLeft);
-		}
-		else {
-			unitValue = timeLeft;
-		}
-
+		let unitValue = unit === "ms"? timeLeft : _.msTo(unit, timeLeft);
 		timeLeft -= unitValue * (unit === "ms" ? 1 : Mavo.Functions[unit]());
 		return unitValue;
 	}).forEach(function (currentValue, index) {
 		if (currentValue !==0 && ret.length < terms) {
 			let unitProperPlurality = currentValue === 1 && units[index] !== "ms" ? units[index].slice(0, -1) : units[index];
-			ret.push(currentValue + " " + _.phrase($this, unitProperPlurality));
+			ret.push(currentValue + " " + Mavo.Functions.phrase($this, unitProperPlurality));
 
 			// so we have a list of unit terms used to later determine whether they're consecutive
 			unitsUsed.push(units[index]);


### PR DESCRIPTION
- Updated duration() to include a second terms parameter for number of time-units up until the user wants their value returned to be in (discarding of in-between zero-valued time-units)
- Added _.toMs in order to convert a value in terms of a given time-unit back to the value in terms of milliseconds