### PR TITLE
Fixes #640

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -59,7 +59,9 @@ Bliss.Class(_, {
 
 				Mavo.hooks.run("expression-compile-error", {context: this, error});
 
-				return this.function = error;
+				this.function = error;
+
+				return value;
 			}
 
 			this.ast = this.options.ast;


### PR DESCRIPTION
We need to save the source expression to use it as a fallback and show it to a user as it is described in the docs: https://mavo.io/docs/expressions#providing-fallbacks-the-mv-value-attribute.