### PR TITLE
Implement storage attributes, resolves #657

### DIFF
--- a/src/backend.dropbox.js
+++ b/src/backend.dropbox.js
@@ -6,8 +6,6 @@ var _ = Mavo.Backend.register($.Class({
 	constructor: function() {
 		this.permissions.on(["login", "read"]);
 
-		this.key = this.mavo.element.getAttribute("mv-dropbox-key") || "2mx6061p054bpbp";
-
 		this.login(true);
 	},
 
@@ -89,6 +87,7 @@ var _ = Mavo.Backend.register($.Class({
 	static: {
 		apiDomain: "https://api.dropboxapi.com/2/",
 		oAuth: "https://www.dropbox.com/oauth2/authorize",
+		key: "2mx6061p054bpbp",
 
 		test: function(url) {
 			url = new URL(url, Mavo.base);

--- a/src/backend.github.js
+++ b/src/backend.github.js
@@ -3,10 +3,14 @@
 var _ = Mavo.Backend.register($.Class({
 	extends: Mavo.Backend,
 	id: "Github",
-	constructor: function() {
+	constructor: function(url, o) {
 		this.permissions.on(["login", "read"]);
 
-		this.key = this.mavo.element.getAttribute("mv-github-key") || "7e08e016048000bc594e";
+		this.login(true);
+	},
+
+	update: function(url, o) {
+		this.super.update.call(this, url, o);
 
 		// Extract info for username, repo, branch, filepath from URL
 		var extension = this.format.constructor.extensions[0] || ".json";
@@ -15,15 +19,6 @@ var _ = Mavo.Backend.register($.Class({
 			repo: "mv-data",
 			filename: `${this.mavo.id}${extension}`
 		};
-
-		this.info = _.parseURL(this.source, this.defaults);
-		$.extend(this, this.info);
-
-		this.login(true);
-	},
-
-	update: function(url, o) {
-		this.super.update.call(this, url, o);
 
 		this.info = _.parseURL(this.source, this.defaults);
 		$.extend(this, this.info);
@@ -342,6 +337,7 @@ var _ = Mavo.Backend.register($.Class({
 	static: {
 		apiDomain: "https://api.github.com/",
 		oAuth: "https://github.com/login/oauth/authorize",
+		key: "7e08e016048000bc594e",
 
 		test: function(url) {
 			url = new URL(url, Mavo.base);

--- a/src/backend.js
+++ b/src/backend.js
@@ -13,9 +13,17 @@ var _ = Mavo.Backend = $.Class({
 
 	update: function(url, o = {}) {
 		this.source = url;
+
+		// Backends that are not URL-based should just ignore this
 		this.url = new URL(this.source, Mavo.base);
+
+		this.options = o;
 		this.mavo = o.mavo;
 		this.format = Mavo.Formats.create(o.format, this);
+
+		if (this.constructor.key ?? o.key) {
+			this.key = o.key ?? this.constructor.key;
+		}
 	},
 
 	async get (url = new URL(this.url)) {
@@ -220,15 +228,16 @@ var _ = Mavo.Backend = $.Class({
 
 	static: {
 		// Return the appropriate backend(s) for this url
-		create: function(url, o, type, existing) {
-			var Backend;
+		create: function(url, o = {}, existing) {
+			let Backend;
 
-			if (type) {
-				Backend = Mavo.Functions.get(_, type);
+			if (o.type) {
+				// Using get() for case-insensitive property lookup
+				Backend = Mavo.Functions.get(_, o.type);
 			}
 
 			if (url && !Backend) {
-				Backend = _.types.filter(Backend => Backend.test(url))[0] || _.Remote;
+				Backend = _.types.find(Backend => Backend.test(url, o)) || _.Remote;
 			}
 
 			// Can we re-use the existing object perhaps?


### PR DESCRIPTION
* Code to read attributes prefixed with `mv-storage-*`, `mv-source-*` etc and send them to the backend code as an object literal
* Replaces ad hoc code for `mv-storage-type` and `mv-storage-format`
* I ported `mv-dropbox-key` and `mv-github-key` to use this new syntax (backwards incompatible since now they'll be `mv-storage-key` etc, but I don't think there is any usage of custom API keys). I also ported that code to `backend.js` since that's where it's actually used.
* There is no code yet to allow attributes to override Github params like username or repo since that turned out to be a little more complicated, so it's better done in a separate commit/PR.