### PR TITLE
Fix issue when there is more than one app on a page

### DIFF
--- a/src/backend.github.js
+++ b/src/backend.github.js
@@ -311,7 +311,7 @@ var _ = Mavo.Backend.register($.Class({
 
 	switchToMyForkDialog: function(forkURL) {
 			let params = (new URL(location)).searchParams;
-			params.append("storage", forkURL + "/" + this.path);
+			params.append(`${this.mavo.id}-storage`, forkURL + "/" + this.path);
 
 			this.notice = this.mavo.message(`
 			${this.mavo._("gh-login-fork-options")}


### PR DESCRIPTION
II believe it would be safer to set the search param this way: by adding an app id. This PR is related to https://github.com/mavoweb/plugins/pull/77.