### PR TITLE
begin moving to let instead of var

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -163,7 +163,9 @@ var _ = Mavo.Actions = {
 				// If to is a number and not a collection item, it's an index
 				[index, to] = [to];
 			}
-
+			//TODO: let->var issue #678
+			//Here is one place where variable hoisting seems to be depended upon with the variable toNode
+			
 			var toNode = _.getNode(to);
 			var fromNodes = Mavo.toArray(from).map(_.getNode).filter(n => n?.closestCollection);
 			var collection = (toNode || fromNodes[0]).closestCollection;

--- a/src/collection.js
+++ b/src/collection.js
@@ -445,7 +445,8 @@ var _ = Mavo.Collection = class Collection extends Mavo.Node {
 				i--;
 			}
 		}
-
+		//TODO: let->var issue #678
+		//it seems like in the for loop above and the if statement below, that the i variable is being re-used from the for loop. this could cause issues in changing it to a let variable
 		if (data.length > i) {
 			// There are still remaining items
 			// Using document fragments improves performance by 60%

--- a/src/data.js
+++ b/src/data.js
@@ -342,9 +342,9 @@ var _ = Mavo.Data = $.Class(class Data {
 					ret = _.find(property, data);
 				}
 			}
-
+			let propertyL;
 			if (!propertyIsNumeric) {
-				var propertyL = property.toLowerCase();
+				propertyL = property.toLowerCase();
 			}
 
 			if (ret !== undefined) {

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -124,13 +124,13 @@ var _ = Mavo.DOMExpression = $.Class({
 	update: function() {
 		var env = {context: this};
 		var parentEnv = env;
-
+		let data;
 		if (this.item) {
 			var scope = this.isDynamicObject? this.item.parent : this.item;
-			var data = this.data = scope.getLiveData();
+			data = this.data = scope.getLiveData();
 		}
 		else {
-			var data = this.data === undefined? Mavo.Data.stub : this.data;
+			data = this.data === undefined? Mavo.Data.stub : this.data;
 		}
 
 		Mavo.hooks.run("domexpression-update-start", env);

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -222,9 +222,9 @@ var _ = Mavo.Expressions = $.Class({
 			if (Mavo.is("item", node)) {
 				path = [];
 			}
-
+			let ignore;
 			if (node.hasAttribute("mv-expressions-ignore")) {
-				var ignore = new Set(node.getAttribute("mv-expressions-ignore").trim().split(/\s*,\s*/));
+				ignore = new Set(node.getAttribute("mv-expressions-ignore").trim().split(/\s*,\s*/));
 			}
 
 			$$(node.attributes).forEach(attribute => {

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -200,7 +200,7 @@ $.extend(_.util, {
 			return "";
 		}
 
-		var ret = ret || numeric[component](dateO);
+		ret = ret || numeric[component](dateO);
 
 		if (format) {
 			if (/^0+$/.test(format)) {

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -188,12 +188,12 @@ $.extend(_.util, {
 		}
 
 		var dateO = $u.date(date);
-
+		let ret;
 		if (component === "year") {
 			// Why +""? We don't want years to be formatted like 2,017!
 			// Why the .match()? For incomplete dates, see #226
 			date = date && date.match? date : date + "";
-			var ret = dateO? dateO.getFullYear() + "" : (date.match(/\b[1-9]\d\d\b|\d+/) || [])[0];
+			ret = dateO? dateO.getFullYear() + "" : (date.match(/\b[1-9]\d\d\b|\d+/) || [])[0];
 		}
 
 		if (!ret && !dateO) {

--- a/src/functions.js
+++ b/src/functions.js
@@ -83,11 +83,11 @@ var _ = Mavo.Functions = {
 		if (id === undefined) {
 			return location.href;
 		}
-
+		let ret;
 		if (id) {
 			id = str(id).replace(/[^\w-:]/g);
 
-			var ret = url.search.match(RegExp(`[?&]${id}(?:=(.+?))?(?=$|&)`))
+			ret = url.search.match(RegExp(`[?&]${id}(?:=(.+?))?(?=$|&)`))
 			       || url.pathname.match(RegExp(`(?:^|\\/)${id}\\/([^\\/]*)`));
 		}
 

--- a/src/group.js
+++ b/src/group.js
@@ -153,10 +153,10 @@ var _ = Mavo.Group = class Group extends Mavo.Node {
 		}
 
 		var changed = false;
-
+		let wasPrimitive;
 		// What if data is not an object?
 		if (typeof data !== "object") {
-			var wasPrimitive = true;
+			wasPrimitive = true;
 
 			// Data is a primitive, render it on this.property or failing that, any writable property
 			if (this.property in this.children) {

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -906,12 +906,12 @@ _.transformations.LogicalExpression = _.transformations.BinaryExpression;
 
 for (let name in _.operators) {
 	let details = _.operators[name];
-
+	let ret;
 	if (details.scalar?.length < 2) {
-		var ret = _.addUnaryOperator(name, details);
+		ret = _.addUnaryOperator(name, details);
 	}
 	else {
-		var ret = _.addBinaryOperator(name, details);
+		ret = _.addBinaryOperator(name, details);
 	}
 
 	details.code = details.code || ret;

--- a/src/mv-if.js
+++ b/src/mv-if.js
@@ -66,9 +66,9 @@ Mavo.Expressions.directive("mv-if", {
 
 			// Only apply this after the tree is built, otherwise any properties inside the if will go missing!
 			await this.item.mavo.treeBuilt;
-
+			let parentValue;
 			if (this.parentIf) {
-				var parentValue = this.parentIf.value[0];
+				parentValue = this.parentIf.value[0];
 				this.value[0] = value = value && parentValue;
 			}
 

--- a/src/node.js
+++ b/src/node.js
@@ -282,11 +282,12 @@ var _ = Mavo.Node = class Node {
 
 		if (!this.isHelperVariable) {
 			if (!Array.isArray(this.children) && Array.isArray(env.data)) {
+				let mainProperty;
 				// We are rendering an array on a singleton, what to do?
 				if (this.isRoot) {
 					// Get the name of the first property that is a collection without mv-value
 					// OR if there is a collection with property="main", prioritize that
-					var mainProperty = this.children.main instanceof Mavo.Collection? "main" : this.getNames((p, n) => {
+					mainProperty = this.children.main instanceof Mavo.Collection? "main" : this.getNames((p, n) => {
 						return n instanceof Mavo.Collection && !n.expressions?.[0]?.isDynamicObject;
 					})[0];
 

--- a/src/util.js
+++ b/src/util.js
@@ -118,8 +118,9 @@ var _ = $.extend(Mavo, {
 	// Delete an element from an array
 	// @param all {Boolean} Delete more than one?
 	delete: (arr, element, all) => {
+		let index;
 		do {
-			var index = arr && arr.indexOf(element);
+			index = arr && arr.indexOf(element);
 
 			if (index > -1) {
 				arr.splice(index, 1);


### PR DESCRIPTION
This pull request (theoretically) fixes #678. I pretty much just did a find and replace across the whole codebase and then only committed the changes to files that weren't in `/dist` (since it seemed like those probably shouldn't be modified.

from a quick search, it seems like the difference between let and var is the scope, and this move would change variable scope from their current function to their current set of `{}`. source: https://stackoverflow.com/questions/762011/whats-the-difference-between-using-let-and-var

I'll work on running the tests to see if everything still works