### PR TITLE
Enhance the Mavo.DOMExpression.special.event() method

### DIFF
--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -306,10 +306,10 @@ var _ = Mavo.DOMExpression = $.Class({
 				this.vars[name] = {
 					observe: function() {
 						this.callback = this.callback || _.special.update.bind(this);
-						target.addEventListener(type, this.callback);
+						$.bind(target, type, this.callback);
 					},
 					unobserve: function() {
-						target.removeEventListener(type, this.callback);
+						$.unbind(target, type, this.callback);
 					}
 				};
 


### PR DESCRIPTION
## Motivation

Recently, I ran into a case where I needed to update a custom special property when either of `mv-login` or `mv-logout` events were being occurred.

I needed to remove user-sensitive data from the DOM when a user was signed out. However, since the `mv-logged-out` class only hides data (visually and semantically), I had to use `mv-if`.

For now, the `$user` special property (see below) can be updated only when the `mv-login` event occurs. But, to remove user data from the DOM, I expect the `$user` property is updated when the `mv-logout` event occurs as well. To solve my problem, I'd like to replace `type: "mv-login"` with `type: "mv-login mv-logout"` (see below).

That's why I suggest using `$.bind()` (`$.unbind()`) instead of `addEventListener` (`removeEventListener`).

To be more precise, consider the following code snippet as an example:
```html

<meta property="userId" content="[$user.info.uid]" />

<ul mv-if="userId" mv-list>
	<li mv-list-item property="task">Do stuff</li>
</ul>

<script>
(async function () {
	await Mavo.ready;

	Mavo.DOMExpression.special.event("$user", {
		type: "mv-login", // type: "mv-login mv-logout"
		update: (evt) => evt.backend.user
	});
})();
</script>
```

I believe this PR might be useful not only in my case but in the future as well.