### PR TITLE
Fix build process so that maps point to the correct files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "gulp-inject-version": "^1",
     "gulp-notify": "^3",
     "gulp-rename": "^2",
-    "gulp-replace": "^1",
+    "gulp-replace": "^1.1.3",
     "gulp-sass": "^4.1.0",
     "gulp-sourcemaps": "^2",
     "merge2": "^1",
-    "sass": "^1.35.1"
+    "sass": "^1.35.1",
+    "sorcery": "^0.10.0"
   }
 }


### PR DESCRIPTION
Let's try to fix the build process so that source maps point to source files, not generated ones.

To make this work I had to remove `sourceMappingURL` from these files:
- `lib/jsep.iife.min.js`
- `lib/jsep.min.js`
- `lib/stretchy.min.js`

It looks like we will have to repeat the same steps every time we update dependencies.