### PR TITLE
[Primitive] Prevent error

### DIFF
--- a/src/primitive.js
+++ b/src/primitive.js
@@ -476,7 +476,7 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 			// e.g. following links etc
 			if (!this.modes || this.modes === "edit") {
 				$.bind(this.element, "click.mavo:edit", evt => {
-					if (this.editor.contains(evt.target)) {
+					if (this.editor?.contains(evt.target)) {
 						evt.preventDefault();
 					}
 				});


### PR DESCRIPTION
Working on [this issue](https://github.com/mavoweb/mavo/issues/738), I noticed a problem with `<meter>`: Uncaught TypeError: Cannot read properties of undefined (reading 'contains') at HTMLMeterElement.<anonymous>.

This PR should fix it.