### PR TITLE
Fix source maps for minified versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,15 +96,20 @@ gulp.task("transpile", function () {
 });
 
 gulp.task("minify", function () {
-	return merge(gulp.src("dist/deps.js"), gulp.src("dist/mavo-nodeps.js").pipe(sourcemaps.init({loadMaps: true})).pipe(minify({mangle: false})))
+	return merge(
+			gulp.src("dist/deps.js").pipe(sourcemaps.init()),
+			gulp.src("dist/mavo-nodeps.js").pipe(sourcemaps.init()).pipe(minify({mangle: false}))
+		)
 		.pipe(concat("mavo.min.js"))
-		.pipe(sourcemaps.mapSources((sourcePath, file) => "../" + sourcePath))
 		.pipe(sourcemaps.write("maps"))
 		.pipe(gulp.dest("dist"));
 });
 
 gulp.task("minify-es5", function () {
-	return merge(gulp.src("dist/deps.js"), transpileStream().pipe(minify({mangle: false})))
+	return merge(
+			gulp.src("dist/deps.js").pipe(sourcemaps.init()),
+			transpileStream().pipe(minify({mangle: false}))
+		)
 		.pipe(concat("mavo.es5.min.js"))
 		.pipe(sourcemaps.mapSources((sourcePath, file) => "../" + sourcePath))
 		.pipe(sourcemaps.write("maps"))


### PR DESCRIPTION
This bug bit me while I was trying to work on #794 — the source maps were pointing to the wrong pieces of the source code. Why? Well, stupid me. I didn't think that if we merge two files but build the source maps for only one of them, the result source maps will be incorrect. 🙄

I also removed the `sourcePath` modification since the paths to the source files in the source maps are already correct.
And I tried to make the code more readable. At least, I think it's more readable now. 😅