### PR TITLE
Tweak the minifier so that it works correctly with ES6 classes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,7 @@ gulp.task("transpile", function () {
 gulp.task("minify", function () {
 	return merge(
 			gulp.src("dist/deps.js").pipe(sourcemaps.init()),
-			gulp.src("dist/mavo-nodeps.js").pipe(sourcemaps.init()).pipe(minify({mangle: false}))
+			gulp.src("dist/mavo-nodeps.js").pipe(sourcemaps.init()).pipe(minify({mangle: false, keepClassName: true, mergeVars: false}))
 		)
 		.pipe(concat("mavo.min.js"))
 		.pipe(sourcemaps.write("maps"))
@@ -108,7 +108,7 @@ gulp.task("minify", function () {
 gulp.task("minify-es5", function () {
 	return merge(
 			gulp.src("dist/deps.js").pipe(sourcemaps.init()),
-			transpileStream().pipe(minify({mangle: false}))
+			transpileStream().pipe(minify({mangle: false, keepClassName: true, mergeVars: false}))
 		)
 		.pipe(concat("mavo.es5.min.js"))
 		.pipe(sourcemaps.mapSources((sourcePath, file) => "../" + sourcePath))


### PR DESCRIPTION
There were two issues with the minifier:
– it was removing class names and
– was merging variable declarations so that sometimes the variables might be left undefined (merging might clash with other code transformations)