### PR TITLE
Allow for specific versions of plugins to be used

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -2,7 +2,7 @@
 
 Mavo.attributes.push("mv-plugins");
 
-var _ = Mavo.Plugins = {
+let _ = Mavo.Plugins = {
 	loaded: {},
 
 	async load () {
@@ -32,15 +32,16 @@ var _ = Mavo.Plugins = {
 				}
 
 				// Load plugin
-				var filename = `mavo-${plugin.id}.js`;
+				let filename = `mavo-${plugin.id}.js`;
+				let url;
 
 				if (plugin.repo) {
 					// Plugin hosted in a separate repo
-					var url = `https://cdn.jsdelivr.net/gh/${plugin.repo}@master/${filename}`;
+					url = `https://cdn.jsdelivr.net/gh/${plugin.repo}@master/${filename}`;
 				}
 				else {
 					// Plugin hosted in the mavo-plugins repo
-					var url = `${_.url}/${plugin.id}/${filename}`;
+					url = `${_.url}/${plugin.id}/${filename}`;
 				}
 
 				return $.include(_.loaded[plugin.id], url);
@@ -66,15 +67,15 @@ var _ = Mavo.Plugins = {
 			}
 		}
 
-		var ready = [];
+		let ready = [];
 
 		if (o.ready) {
 			ready.push(o.ready);
 		}
 
 		if (o.dependencies) {
-			var base = document.currentScript? document.currentScript.src : location;
-			var dependencies = o.dependencies.map(url => Mavo.load(url, base));
+			let base = document.currentScript? document.currentScript.src : location;
+			let dependencies = o.dependencies.map(url => Mavo.load(url, base));
 			ready.push(...dependencies);
 		}
 


### PR DESCRIPTION
We discussed this feature once here: #603. And I decided to give it a shot.

For now, it works only for plugins hosted in a separate repo. I'm not sure whether it's possible to release our plugins separately (since all of them are in the same repo).

I also bumped into an issue: it looks like we download all versions of a plugin even though we expect that the first specified version wins (in the order the plugins are specified in `mv-plugins`). Why do we expect this? Because of this line:
```js
if (_.loaded[plugin.id]) {
	return Promise.resolve();
}
```
However, it looks like we add plugins to the `loaded` object too late (inside `Mavo.Plugins.registered()`).

Are there any thoughts on how to fix it?