### PR TITLE
Clicking on editable property inside <a> mustn't trigger the link

### DIFF
--- a/src/primitive.js
+++ b/src/primitive.js
@@ -449,14 +449,14 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 	}
 
 	edit (o = {}) {
-		let wasEditing = this.editing;
+		let wasEditing = this.editing && !this.initEdit;
 
 		if (super.edit(o) === false) {
 			// Invalid edit
 			return false;
 		}
 
-		if (!o.force && wasEditing && !this.initEdit) {
+		if (!o.force && wasEditing) {
 			// Already being edited
 			return true;
 		}
@@ -476,7 +476,7 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 			// e.g. following links etc
 			if (!this.modes) {
 				$.bind(this.element, "click.mavo:edit", evt => {
-					if (this.editor?.contains(evt.target)) {
+					if (evt.target === this.editor || !this.editor.contains(evt.target)) {
 						evt.preventDefault();
 					}
 				});


### PR DESCRIPTION
Let's try to fix this issue one more time.

This fix doesn't cover this case. But it looks so weird. I can't even imagine when we need it. But maybe it's just me. 😅
```html
<a href="foo.html"><span property="yolo" mv-mode="edit">yolo</span></a>
```

I tested all the known cases and regressions (including the fresh one you built) and checked the test suite. It looks like everything works as expected. 🤞🏻