### PR TITLE
feat: consistent function naming with underscores

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -572,7 +572,7 @@ var _ = Mavo.Functions = {
 	tofirst: $.extend((haystack, needle) => {
 		Mavo.warn("tofirst() is deprecated and will be removed in the next version of Mavo. Please use to_first() instead.");
 		return _.to_first(haystack, needle);
-	},
+	}),
 
 	between: $.extend((haystack, from, to, tight) => {
 		[haystack, from, to] = [str(haystack), str(from), str(to)];

--- a/src/functions.js
+++ b/src/functions.js
@@ -565,7 +565,7 @@ var _ = Mavo.Functions = {
 
 	tofirst: (haystack, needle) => {
 		Mavo.warn("tofirst() is deprecated and will be removed in the next version of Mavo. Please use to_first() instead.");
-		Mavo.tofirst(haystack, needle);
+		Mavo.to_first(haystack, needle);
 	},
 
 	to_first: $.extend((haystack, needle) => _.between(haystack, "", needle, true), {

--- a/src/functions.js
+++ b/src/functions.js
@@ -554,7 +554,7 @@ var _ = Mavo.Functions = {
 		multiValued: true,
 	}),
 
-	fromlast: deprecatedFunction("from_last", "fromlast"),
+	fromlast: Mavo.deprecatedFunction("from_last", "fromlast"),
 
 	to: $.extend((haystack, needle) => _.between(haystack, "", needle), {
 		multiValued: true,
@@ -564,7 +564,7 @@ var _ = Mavo.Functions = {
 		multiValued: true,
 	}),
 
-	tofirst: deprecatedFunction("to_first", "tofirst"),
+	tofirst: Mavo.deprecatedFunction("to_first", "tofirst"),
 
 	between: $.extend((haystack, from, to, tight) => {
 		[haystack, from, to] = [str(haystack), str(from), str(to)];
@@ -746,14 +746,6 @@ function empty(v) {
 
 function not(v) {
 	return !val(v);
-}
-
-function deprecatedFunction (name, oldName, fn) {
-	return function (...args) {
-		fn ??= _[name];
-		Mavo.warn(`${oldName}() is deprecated and will be removed in the next version of Mavo. Please use ${name}() instead.`);
-		return fn(...args);
-	}
 }
 
 })(Bliss, Mavo.value);

--- a/src/functions.js
+++ b/src/functions.js
@@ -550,12 +550,14 @@ var _ = Mavo.Functions = {
 		multiValued: true,
 	}),
 
-	fromlast: (haystack, needle) => {
-		Mavo.warn("fromlast() is deprecated and will be removed in the next version of Mavo. Please use from_last() instead.");
-		return from_last(haystack, needle);
-	},
-
 	from_last: $.extend((haystack, needle) => _.between(haystack, needle, "", true), {
+		multiValued: true,
+	}),
+
+	fromlast: $.extend((haystack, needle) => {
+		Mavo.warn("fromlast() is deprecated and will be removed in the next version of Mavo. Please use from_last() instead.");
+		return _.from_last(haystack, needle);
+	}, {
 		multiValued: true,
 	}),
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -547,32 +547,24 @@ var _ = Mavo.Functions = {
 	}),
 
 	from: $.extend((haystack, needle) => _.between(haystack, needle), {
-		multiValued: true,
+		multiValued: true
 	}),
 
 	from_last: $.extend((haystack, needle) => _.between(haystack, needle, "", true), {
-		multiValued: true,
+		multiValued: true
 	}),
 
-	fromlast: $.extend((haystack, needle) => {
-		Mavo.warn("fromlast() is deprecated and will be removed in the next version of Mavo. Please use from_last() instead.");
-		return _.from_last(haystack, needle);
-	}, {
-		multiValued: true,
-	}),
+	fromlast: deprecatedFunction("from_last", "fromlast"),
 
 	to: $.extend((haystack, needle) => _.between(haystack, "", needle), {
-		multiValued: true,
+		multiValued: true
 	}),
 
 	to_first: $.extend((haystack, needle) => _.between(haystack, "", needle, true), {
-		multiValued: true,
+		multiValued: true
 	}),
 
-	tofirst: $.extend((haystack, needle) => {
-		Mavo.warn("tofirst() is deprecated and will be removed in the next version of Mavo. Please use to_first() instead.");
-		return _.to_first(haystack, needle);
-	}),
+	tofirst: deprecatedFunction("to_first", "tofirst"),
 
 	between: $.extend((haystack, from, to, tight) => {
 		[haystack, from, to] = [str(haystack), str(from), str(to)];
@@ -754,6 +746,14 @@ function empty(v) {
 
 function not(v) {
 	return !val(v);
+}
+
+function deprecatedFunction (name, oldName, fn) {
+	return function (...args) {
+		fn ??= _[name];
+		Mavo.warn(`${oldName}() is deprecated and will be removed in the next version of Mavo. Please use ${name}() instead.`);
+		return fn(...args);
+	}
 }
 
 })(Bliss, Mavo.value);

--- a/src/functions.js
+++ b/src/functions.js
@@ -565,14 +565,14 @@ var _ = Mavo.Functions = {
 		multiValued: true,
 	}),
 
-	tofirst: (haystack, needle) => {
-		Mavo.warn("tofirst() is deprecated and will be removed in the next version of Mavo. Please use to_first() instead.");
-		Mavo.to_first(haystack, needle);
-	},
-
 	to_first: $.extend((haystack, needle) => _.between(haystack, "", needle, true), {
 		multiValued: true,
 	}),
+
+	tofirst: $.extend((haystack, needle) => {
+		Mavo.warn("tofirst() is deprecated and will be removed in the next version of Mavo. Please use to_first() instead.");
+		return _.to_first(haystack, needle);
+	},
 
 	between: $.extend((haystack, from, to, tight) => {
 		[haystack, from, to] = [str(haystack), str(from), str(to)];

--- a/src/functions.js
+++ b/src/functions.js
@@ -547,21 +547,21 @@ var _ = Mavo.Functions = {
 	}),
 
 	from: $.extend((haystack, needle) => _.between(haystack, needle), {
-		multiValued: true
+		multiValued: true,
 	}),
 
 	from_last: $.extend((haystack, needle) => _.between(haystack, needle, "", true), {
-		multiValued: true
+		multiValued: true,
 	}),
 
 	fromlast: deprecatedFunction("from_last", "fromlast"),
 
 	to: $.extend((haystack, needle) => _.between(haystack, "", needle), {
-		multiValued: true
+		multiValued: true,
 	}),
 
 	to_first: $.extend((haystack, needle) => _.between(haystack, "", needle, true), {
-		multiValued: true
+		multiValued: true,
 	}),
 
 	tofirst: deprecatedFunction("to_first", "tofirst"),

--- a/src/functions.js
+++ b/src/functions.js
@@ -550,7 +550,12 @@ var _ = Mavo.Functions = {
 		multiValued: true,
 	}),
 
-	fromlast: $.extend((haystack, needle) => _.between(haystack, needle, "", true), {
+	fromlast: (haystack, needle) => {
+		Mavo.warn("fromlast() is deprecated and will be removed in the next version of Mavo. Please use from_last() instead.");
+		return from_last(haystack, needle);
+	},
+
+	from_last: $.extend((haystack, needle) => _.between(haystack, needle, "", true), {
 		multiValued: true,
 	}),
 
@@ -558,7 +563,12 @@ var _ = Mavo.Functions = {
 		multiValued: true,
 	}),
 
-	tofirst: $.extend((haystack, needle) => _.between(haystack, "", needle, true), {
+	tofirst: (haystack, needle) => {
+		Mavo.warn("tofirst() is deprecated and will be removed in the next version of Mavo. Please use to_first() instead.");
+		Mavo.tofirst(haystack, needle);
+	},
+
+	to_first: $.extend((haystack, needle) => _.between(haystack, "", needle, true), {
 		multiValued: true,
 	}),
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -4,7 +4,79 @@
 
 (function($, val) {
 
-var _ = Mavo.Functions = {
+let $u = {
+	numbers (array, args) {
+		array = Array.isArray(array)? array : (args? $$(args) : [array]);
+
+		return array.filter(number => !isNaN(number) && val(number) !== "" && val(number) !== null).map(n => +n);
+	},
+
+	// Implement function metadata
+	postProcess (callback) {
+		var multiValued = callback.multiValued;
+		var newCallback;
+
+		if (multiValued === true || multiValued?.length === 2) {
+			newCallback = (...args) => {
+				// Define index of multiValued arguments
+				// Fallback to first 2 arguments if not explicitly defined
+				var idxA = multiValued[0] || 0;
+				var idxB = multiValued[1] || 1;
+
+				return Mavo.Script.binaryOperation(args[idxA], args[idxB], {
+					scalar: (a, b) => {
+						// Replace multiValued argument with its individual elements
+						if (idxA in args) {
+							args[idxA] = a;
+						}
+
+						if (idxB in args) {
+							args[idxB] = b;
+						}
+
+						return callback(...args);
+					},
+					...callback
+				});
+			};
+		}
+		else if (callback.isAggregate) {
+			newCallback = function(array) {
+				if (Mavo.in(Mavo.groupedBy, array)) { // grouped structures
+					return array.map(e => newCallback(e.$items));
+				}
+
+				var ret = callback.call(this, ...arguments);
+
+				return ret === undefined? array : ret;
+			};
+		}
+
+		if (newCallback) {
+			// Preserve function metadata
+			$.extend(newCallback, callback);
+			newCallback.original = callback;
+		}
+
+		if (callback.alias) {
+			for (let alias of Mavo.toArray(callback.alias)) {
+				Mavo.Functions[alias] = newCallback || callback;
+			}
+		}
+
+		return newCallback;
+	},
+
+	deprecatedFunction (name, oldName, fn) {
+		return function (...args) {
+			fn ??= Mavo.Functions[name];
+			Mavo.warn(`${oldName}() is deprecated and will be removed in the next version of Mavo. Please use ${name}() instead.`);
+			return fn(...args);
+		}
+	}
+}
+
+let _ = Mavo.Functions = {
 	operators: {
 		"=": "eq"
 	},
@@ -554,7 +626,7 @@ var _ = Mavo.Functions = {
 		multiValued: true,
 	}),
 
-	fromlast: Mavo.deprecatedFunction("from_last", "fromlast"),
+	fromlast: $u.deprecatedFunction("from_last", "fromlast"),
 
 	to: $.extend((haystack, needle) => _.between(haystack, "", needle), {
 		multiValued: true,
@@ -564,7 +636,7 @@ var _ = Mavo.Functions = {
 		multiValued: true,
 	}),
 
-	tofirst: Mavo.deprecatedFunction("to_first", "tofirst"),
+	tofirst: $u.deprecatedFunction("to_first", "tofirst"),
 
 	between: $.extend((haystack, from, to, tight) => {
 		[haystack, from, to] = [str(haystack), str(from), str(to)];
@@ -641,72 +713,8 @@ var _ = Mavo.Functions = {
 	},
 
 	// "Private" helpers
-	util: {
-		numbers: function(array, args) {
-			array = Array.isArray(array)? array : (args? $$(args) : [array]);
-
-			return array.filter(number => !isNaN(number) && val(number) !== "" && val(number) !== null).map(n => +n);
-		},
-
-		// Implement function metadata
-		postProcess: function(callback) {
-			var multiValued = callback.multiValued;
-			var newCallback;
-
-			if (multiValued === true || multiValued?.length === 2) {
-				newCallback = (...args) => {
-					// Define index of multiValued arguments
-					// Fallback to first 2 arguments if not explicitly defined
-					var idxA = multiValued[0] || 0;
-					var idxB = multiValued[1] || 1;
-
-					return Mavo.Script.binaryOperation(args[idxA], args[idxB], {
-						scalar: (a, b) => {
-							// Replace multiValued argument with its individual elements
-							if (idxA in args) {
-								args[idxA] = a;
-							}
-
-							if (idxB in args) {
-								args[idxB] = b;
-							}
-
-							return callback(...args);
-						},
-						...callback
-					});
-				};
-			}
-			else if (callback.isAggregate) {
-				newCallback = function(array) {
-					if (Mavo.in(Mavo.groupedBy, array)) { // grouped structures
-						return array.map(e => newCallback(e.$items));
-					}
-
-					var ret = callback.call(this, ...arguments);
-
-					return ret === undefined? array : ret;
-				};
-			}
-
-			if (newCallback) {
-				// Preserve function metadata
-				$.extend(newCallback, callback);
-				newCallback.original = callback;
-			}
-
-			if (callback.alias) {
-				for (let alias of Mavo.toArray(callback.alias)) {
-					Mavo.Functions[alias] = newCallback || callback;
-				}
-			}
-
-			return newCallback;
-		}
-	}
+	util: $u
 };
-
-var $u = _.util;
 
 /**
  * After plugins are loaded, enable

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -492,7 +492,6 @@ var _ = Mavo.Script = {
 			precedence: 2
 		},
 		"groupby": {
-			symbol: "by",
 			code: (array, key) => {
 				Mavo.warn("groupby() is deprecated and will be removed in the next version of Mavo. Please use group_by() instead.");
 				return Mavo.Functions["group_by"](array, key);

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -453,14 +453,6 @@ var _ = Mavo.Script = {
 			},
 			precedence: 3
 		},
-		"groupby": {
-			symbol: "by",
-			code: (array, key) => {
-				Mavo.warn("groupby() is deprecated and will be removed in the next version of Mavo. Please use group_by() instead.");
-				Mavo.group_by(array, key);
-			},
-			precedence: 2
-		},
 		"group_by": {
 			symbol: "by",
 			code: (array, key) => {
@@ -496,6 +488,14 @@ var _ = Mavo.Script = {
 				});
 
 				return Mavo.Data.proxify(ret);
+			},
+			precedence: 2
+		},
+		"groupby": {
+			symbol: "by",
+			code: (array, key) => {
+				Mavo.warn("groupby() is deprecated and will be removed in the next version of Mavo. Please use group_by() instead.");
+				return Mavo.Functions['group_by'](array, key);
 			},
 			precedence: 2
 		},

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -495,7 +495,7 @@ var _ = Mavo.Script = {
 			symbol: "by",
 			code: (array, key) => {
 				Mavo.warn("groupby() is deprecated and will be removed in the next version of Mavo. Please use group_by() instead.");
-				return Mavo.Functions['group_by'](array, key);
+				return Mavo.Functions["group_by"](array, key);
 			},
 			precedence: 2
 		},

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -492,7 +492,7 @@ var _ = Mavo.Script = {
 			precedence: 2
 		},
 		"groupby": {
-			code: Mavo.deprecatedFunction("group_by", "groupby"),
+			code: $u.deprecatedFunction("group_by", "groupby"),
 			precedence: 2
 		},
 		"as": {

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -456,6 +456,14 @@ var _ = Mavo.Script = {
 		"groupby": {
 			symbol: "by",
 			code: (array, key) => {
+				Mavo.warn("groupby() is deprecated and will be removed in the next version of Mavo. Please use group_by() instead.");
+				Mavo.group_by(array, key);
+			},
+			precedence: 2
+		},
+		"group_by": {
+			symbol: "by",
+			code: (array, key) => {
 				array = Mavo.toArray(array);
 				key = Mavo.toArray(key);
 				var property = key[Mavo.as] || key[0]?.[Mavo.toNode]?.property;

--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -492,10 +492,7 @@ var _ = Mavo.Script = {
 			precedence: 2
 		},
 		"groupby": {
-			code: (array, key) => {
-				Mavo.warn("groupby() is deprecated and will be removed in the next version of Mavo. Please use group_by() instead.");
-				return Mavo.Functions["group_by"](array, key);
-			},
+			code: Mavo.deprecatedFunction("group_by", "groupby"),
 			precedence: 2
 		},
 		"as": {

--- a/src/util.js
+++ b/src/util.js
@@ -775,14 +775,6 @@ var _ = $.extend(Mavo, {
 		forEach(...args) {
 			return this.map.forEach(...args);
 		}
-	},
-
-	deprecatedFunction (name, oldName, fn) {
-		return function (...args) {
-			fn ??= Mavo.Functions[name];
-			Mavo.warn(`${oldName}() is deprecated and will be removed in the next version of Mavo. Please use ${name}() instead.`);
-			return fn(...args);
-		}
 	}
 });
 

--- a/src/util.js
+++ b/src/util.js
@@ -775,6 +775,14 @@ var _ = $.extend(Mavo, {
 		forEach(...args) {
 			return this.map.forEach(...args);
 		}
+	},
+
+	deprecatedFunction (name, oldName, fn) {
+		return function (...args) {
+			fn ??= Mavo.Functions[name];
+			Mavo.warn(`${oldName}() is deprecated and will be removed in the next version of Mavo. Please use ${name}() instead.`);
+			return fn(...args);
+		}
 	}
 });
 


### PR DESCRIPTION
This PR is a solution for #793 issue.

Function calls are tested after renaming and working exact the same way as before. There are extra warnings on the console for old function calls for the following cases:
- `groupby()` function call,
- `fromlast()` and `tofirst()` calls.

Let me know if you have any suggestions. Thank you! 🙇 👍 