### PR TITLE
A way for attributes to contain expressions without triggering browser errors or false loading

### DIFF
--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -35,7 +35,7 @@ var _ = Mavo.DOMExpression = $.Class({
 			this.originalAttribute = this.attribute;
 			this.attribute = this.attribute.replace("mv-attr-", "");
 
-			if (this.element.namespaceURI === "http://www.w3.org/2000/svg") {
+			if (["http://www.w3.org/2000/svg", "http://www.w3.org/1998/Math/MathML"].includes(this.element.namespaceURI)) {
 				this.attribute = Mavo.getProperAttributeCase(this.element, this.attribute);
 			}
 

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -43,6 +43,10 @@ var _ = Mavo.DOMExpression = $.Class({
 			}
 
 			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
+			let expression = this.element.getAttribute(this.originalAttribute);
+			this.element.removeAttribute(this.originalAttribute);
+			this.parsed = [new Mavo.Expression(expression)];
+			this.expression = expression;
 		}
 
 		if (this.node.nodeType === 3 && this.element === this.node) {
@@ -62,14 +66,7 @@ var _ = Mavo.DOMExpression = $.Class({
 
 		if (typeof this.expression !== "string") { // Still unhandled?
 			if (this.attribute) {
-				let value;
-				if (this.originalAttribute?.startsWith("mv-attr-")) {
-					value = originalGetAttribute.call(this.node, this.originalAttribute);
-					this.node.removeAttribute(this.originalAttribute);
-				}
-				else {
-					value = originalGetAttribute.call(this.node, this.attribute);
-				}
+				let value = originalGetAttribute.call(this.node, this.attribute);
 
 				this.expression = (value || "").trim();
 			}

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -60,13 +60,15 @@ var _ = Mavo.DOMExpression = $.Class({
 		if (typeof this.expression !== "string") { // Still unhandled?
 			if (this.attribute) {
 				// Some web components (e.g. AFrame) hijack getAttribute()
+				const originalGetAttribute = Element.prototype.getAttribute;
+
 				let value;
 				if (this.originalAttribute?.startsWith("mv-attr-")) {
-					value = Element.prototype.getAttribute.call(this.node, this.originalAttribute);
+					value = originalGetAttribute.call(this.node, this.originalAttribute);
 					this.node.removeAttribute(this.originalAttribute);
 				}
 				else {
-					value = Element.prototype.getAttribute.call(this.node, this.attribute);
+					value = originalGetAttribute.call(this.node, this.attribute);
 				}
 
 				this.expression = (value || "").trim();

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -34,7 +34,11 @@ var _ = Mavo.DOMExpression = $.Class({
 		if (this.attribute?.startsWith("mv-attr-")) {
 			this.originalAttribute = this.attribute;
 			this.attribute = this.attribute.replace("mv-attr-", "");
-			this.attribute = Mavo.adjustSVGAttribute(this.attribute);
+
+			if (this.element.namespaceURI === "http://www.w3.org/2000/svg") {
+				this.attribute = Mavo.getProperCasing(this.element.nodeName, this.attribute);
+			}
+
 			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
 		}
 

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -36,7 +36,7 @@ var _ = Mavo.DOMExpression = $.Class({
 			this.attribute = this.attribute.replace("mv-attr-", "");
 
 			if (this.element.namespaceURI === "http://www.w3.org/2000/svg") {
-				this.attribute = Mavo.getProperAttributeCase(this.element.nodeName, this.attribute);
+				this.attribute = Mavo.getProperAttributeCase(this.element, this.attribute);
 			}
 
 			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -1,5 +1,8 @@
 (function($, $$) {
 
+// Some web components (e.g. AFrame) hijack getAttribute()
+const originalGetAttribute = Element.prototype.getAttribute;
+
 var _ = Mavo.DOMExpression = $.Class({
 	async constructor (o = {}) {
 		this.mavo = o.mavo;
@@ -59,9 +62,6 @@ var _ = Mavo.DOMExpression = $.Class({
 
 		if (typeof this.expression !== "string") { // Still unhandled?
 			if (this.attribute) {
-				// Some web components (e.g. AFrame) hijack getAttribute()
-				const originalGetAttribute = Element.prototype.getAttribute;
-
 				let value;
 				if (this.originalAttribute?.startsWith("mv-attr-")) {
 					value = originalGetAttribute.call(this.node, this.originalAttribute);

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -27,22 +27,22 @@ var _ = Mavo.DOMExpression = $.Class({
 
 		Mavo.hooks.run("domexpression-init-start", this);
 
-		if (this.attribute == "mv-value") {
-			this.originalAttribute = "mv-value";
-			this.attribute = Mavo.Primitive.getValueAttribute(this.element);
-			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
-			let expression = this.element.getAttribute("mv-value");
-			this.element.removeAttribute("mv-value");
-			this.parsed = [new Mavo.Expression(expression)];
-			this.expression = expression;
-		}
-
-		if (this.attribute?.startsWith("mv-attr-")) {
+		if (/^mv-(value$|attr-)/.test(this.attribute)) {
+			// Attributes transformed to other attributes
 			this.originalAttribute = this.attribute;
-			this.attribute = this.attribute.replace("mv-attr-", "");
 
-			if ([SVG_NAMESPACE_URI, MATHML_NAMESPACE_URI].includes(this.element.namespaceURI)) {
-				this.attribute = Mavo.getProperAttributeCase(this.element, this.attribute);
+			if (this.attribute == "mv-value") {
+				this.attribute = Mavo.Primitive.getValueAttribute(this.element);
+			}
+			else {
+				this.attribute = this.attribute.replace("mv-attr-", "");
+
+				// Get proper attribute case if in a case sensitive environment
+				// FIXME do we also need this for XHTML?
+				// FIXME what about namespaced attributes? (e.g. xlink:href)
+				if ([SVG_NAMESPACE_URI, MATHML_NAMESPACE_URI].includes(this.element.namespaceURI)) {
+					this.attribute = Mavo.getProperAttributeCase(this.element, this.attribute);
+				}
 			}
 
 			this.fallback ??= Mavo.Primitive.getValue(this.element, {attribute: this.attribute});

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -36,7 +36,7 @@ var _ = Mavo.DOMExpression = $.Class({
 			this.attribute = this.attribute.replace("mv-attr-", "");
 
 			if (this.element.namespaceURI === "http://www.w3.org/2000/svg") {
-				this.attribute = Mavo.getProperCasing(this.element.nodeName, this.attribute);
+				this.attribute = Mavo.getProperAttributeCase(this.element.nodeName, this.attribute);
 			}
 
 			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -3,6 +3,9 @@
 // Some web components (e.g. AFrame) hijack getAttribute()
 const originalGetAttribute = Element.prototype.getAttribute;
 
+const SVG_NAMESPACE_URI = "http://www.w3.org/2000/svg";
+const MATHML_NAMESPACE_URI = "http://www.w3.org/1998/Math/MathML";
+
 var _ = Mavo.DOMExpression = $.Class({
 	async constructor (o = {}) {
 		this.mavo = o.mavo;
@@ -38,7 +41,7 @@ var _ = Mavo.DOMExpression = $.Class({
 			this.originalAttribute = this.attribute;
 			this.attribute = this.attribute.replace("mv-attr-", "");
 
-			if (["http://www.w3.org/2000/svg", "http://www.w3.org/1998/Math/MathML"].includes(this.element.namespaceURI)) {
+			if ([SVG_NAMESPACE_URI, MATHML_NAMESPACE_URI].includes(this.element.namespaceURI)) {
 				this.attribute = Mavo.getProperAttributeCase(this.element, this.attribute);
 			}
 

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -120,17 +120,7 @@ var _ = Mavo.DOMExpression = $.Class({
 			this.item.expressions.delete(this);
 		}
 
-		let expressions = [...this.item.expressions].filter(e => e.attribute === this.attribute && e.active !== false);
-		if (expressions.some(e => e.originalAttribute?.startsWith("mv-attr-"))) {
-			for (let expression of expressions.filter(e => !e.originalAttribute?.startsWith("mv-attr-"))) {
-				// We already have expressions associated with this attribute; discard them since mv-attr-* has priority
-				expression.active = false;
-			}
-		}
-
-		if (this.active !== false) {
-			this.mavo.expressions.register(this);
-		}
+		this.mavo.expressions.register(this);
 
 		Mavo.hooks.run("domexpression-init-treebuilt", this);
 	},

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -45,7 +45,7 @@ var _ = Mavo.DOMExpression = $.Class({
 				this.attribute = Mavo.getProperAttributeCase(this.element, this.attribute);
 			}
 
-			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
+			this.fallback ??= Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
 			let expression = this.element.getAttribute(this.originalAttribute);
 			this.element.removeAttribute(this.originalAttribute);
 			this.parsed = [new Mavo.Expression(expression)];

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -34,6 +34,7 @@ var _ = Mavo.DOMExpression = $.Class({
 		if (this.attribute?.startsWith("mv-attr-")) {
 			this.originalAttribute = this.attribute;
 			this.attribute = this.attribute.replace("mv-attr-", "");
+			this.attribute = Mavo.adjustSVGAttribute(this.attribute);
 			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
 		}
 

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -120,7 +120,17 @@ var _ = Mavo.DOMExpression = $.Class({
 			this.item.expressions.delete(this);
 		}
 
-		this.mavo.expressions.register(this);
+		let expressions = [...this.item.expressions].filter(e => e.attribute === this.attribute && e.active !== false);
+		if (expressions.some(e => e.originalAttribute?.startsWith("mv-attr-"))) {
+			for (let expression of expressions.filter(e => !e.originalAttribute?.startsWith("mv-attr-"))) {
+				// We already have expressions associated with this attribute; discard them since mv-attr-* has priority
+				expression.active = false;
+			}
+		}
+
+		if (this.active !== false) {
+			this.mavo.expressions.register(this);
+		}
 
 		Mavo.hooks.run("domexpression-init-treebuilt", this);
 	},

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -21,19 +21,20 @@ var _ = Mavo.DOMExpression = $.Class({
 
 		Mavo.hooks.run("domexpression-init-start", this);
 
-		if (this.attribute === "mv-value" || this.attribute?.startsWith("mv-attr-")) {
-			let replaceableAttribute;
-			if (this.attribute.startsWith("mv-attr-")) {
-				replaceableAttribute = this.attribute.replace("mv-attr-", "");
-			}
-
-			this.originalAttribute = this.attribute;
-			this.attribute = replaceableAttribute ?? Mavo.Primitive.getValueAttribute(this.element);
+		if (this.attribute == "mv-value") {
+			this.originalAttribute = "mv-value";
+			this.attribute = Mavo.Primitive.getValueAttribute(this.element);
 			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
-			let expression = this.element.getAttribute(this.originalAttribute);
-			this.element.removeAttribute(this.originalAttribute);
+			let expression = this.element.getAttribute("mv-value");
+			this.element.removeAttribute("mv-value");
 			this.parsed = [new Mavo.Expression(expression)];
 			this.expression = expression;
+		}
+
+		if (this.attribute?.startsWith("mv-attr-")) {
+			this.originalAttribute = this.attribute;
+			this.attribute = this.attribute.replace("mv-attr-", "");
+			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
 		}
 
 		if (this.node.nodeType === 3 && this.element === this.node) {
@@ -54,7 +55,14 @@ var _ = Mavo.DOMExpression = $.Class({
 		if (typeof this.expression !== "string") { // Still unhandled?
 			if (this.attribute) {
 				// Some web components (e.g. AFrame) hijack getAttribute()
-				var value = Element.prototype.getAttribute.call(this.node, this.attribute);
+				let value;
+				if (this.originalAttribute?.startsWith("mv-attr-")) {
+					value = Element.prototype.getAttribute.call(this.node, this.originalAttribute);
+					this.node.removeAttribute(this.originalAttribute);
+				}
+				else {
+					value = Element.prototype.getAttribute.call(this.node, this.attribute);
+				}
 
 				this.expression = (value || "").trim();
 			}

--- a/src/domexpression.js
+++ b/src/domexpression.js
@@ -21,12 +21,17 @@ var _ = Mavo.DOMExpression = $.Class({
 
 		Mavo.hooks.run("domexpression-init-start", this);
 
-		if (this.attribute == "mv-value") {
-			this.originalAttribute = "mv-value";
-			this.attribute = Mavo.Primitive.getValueAttribute(this.element);
+		if (this.attribute === "mv-value" || this.attribute?.startsWith("mv-attr-")) {
+			let replaceableAttribute;
+			if (this.attribute.startsWith("mv-attr-")) {
+				replaceableAttribute = this.attribute.replace("mv-attr-", "");
+			}
+
+			this.originalAttribute = this.attribute;
+			this.attribute = replaceableAttribute ?? Mavo.Primitive.getValueAttribute(this.element);
 			this.fallback = this.fallback || Mavo.Primitive.getValue(this.element, {attribute: this.attribute});
-			let expression = this.element.getAttribute("mv-value");
-			this.element.removeAttribute("mv-value");
+			let expression = this.element.getAttribute(this.originalAttribute);
+			this.element.removeAttribute(this.originalAttribute);
 			this.parsed = [new Mavo.Expression(expression)];
 			this.expression = expression;
 		}

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -228,25 +228,24 @@ var _ = Mavo.Expressions = $.Class({
 				ignore = new Set(node.getAttribute("mv-expressions-ignore").trim().split(/\s*,\s*/));
 			}
 
-			let attributes = $$(node.attributes);
+			let specifiedAttributes = new Set(node.getAttributeNames());
 
-			// Iterate only over mv-attr-foo with expressions
-			for (let attribute of attributes.filter(attribute => attribute.name.startsWith("mv-attr-") && syntax.test(attribute.value))) {
-				let name = attribute.name.replace("mv-attr-", "");
-				let ignorable = attributes.find(attribute => attribute.name === name);
+			// Remove ignored attributes
+			for (let name of specifiedAttributes) {
+				if (ignore.has(name)) {
+					specifiedAttributes.delete(name);
+				}
 
-				if (ignorable) {
-					// Ignore expressions in foo, if any, since mv-attr-foo has priority
-					ignore ??= new Set();
-					ignore.add(ignorable.name);
+				if (name.startsWith("mv-attr-")) {
+					// If mv-attr-foo is present, ignore foo
+					let plainName = name.replace("mv-attr-", "");
+					specifiedAttributes.delete(plainName);
 				}
 			}
 
-			attributes.forEach(attribute => {
-				if (!ignore || !ignore.has(attribute.name)) {
-					this.extract(node, attribute, path, syntax);
-				}
-			});
+			for (let name of specifiedAttributes) {
+				this.extract(node, node.attributes[name], path, syntax);
+			}
 
 			var index = -1, offset = 0;
 

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -184,10 +184,6 @@ var _ = Mavo.Expressions = $.Class({
 
 	extract: function(node, attribute, path, syntax = Mavo.Expression.Syntax.default) {
 		let attributeName = attribute?.name;
-		if (_.skip.includes(attributeName)) {
-			return;
-		}
-
 		if (_.directives.some(d => d.test?.(attributeName) || d === attributeName) ||
 		    syntax !== Mavo.Expression.Syntax.ESCAPE && syntax.test(attribute? attribute.value : node.textContent)
 		) {

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -223,11 +223,26 @@ var _ = Mavo.Expressions = $.Class({
 				path = [];
 			}
 
+			let ignore;
 			if (node.hasAttribute("mv-expressions-ignore")) {
-				var ignore = new Set(node.getAttribute("mv-expressions-ignore").trim().split(/\s*,\s*/));
+				ignore = new Set(node.getAttribute("mv-expressions-ignore").trim().split(/\s*,\s*/));
 			}
 
-			$$(node.attributes).forEach(attribute => {
+			let attributes = $$(node.attributes);
+
+			// Iterate only over mv-attr-foo with expressions
+			for (let attribute of attributes.filter(attribute => attribute.name.startsWith("mv-attr-") && syntax.test(attribute.value))) {
+				let name = attribute.name.replace("mv-attr-", "");
+				let ignorable = attributes.find(attribute => attribute.name === name);
+
+				if (ignorable) {
+					// Ignore expressions in foo, if any, since mv-attr-foo has priority
+					ignore ??= new Set();
+					ignore.add(ignorable.name);
+				}
+			}
+
+			attributes.forEach(attribute => {
 				if (!ignore || !ignore.has(attribute.name)) {
 					this.extract(node, attribute, path, syntax);
 				}

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -183,11 +183,12 @@ var _ = Mavo.Expressions = $.Class({
 	},
 
 	extract: function(node, attribute, path, syntax = Mavo.Expression.Syntax.default) {
-		if (_.skip.includes(attribute?.name)) {
+		let attributeName = attribute?.name;
+		if (_.skip.includes(attributeName)) {
 			return;
 		}
 
-		if (_.directives.includes(attribute?.name) || attribute?.name?.startsWith("mv-attr-") ||
+		if (_.directives.some(d => d.test?.(attributeName) || d === attributeName) ||
 		    syntax !== Mavo.Expression.Syntax.ESCAPE && syntax.test(attribute? attribute.value : node.textContent)
 		) {
 			if (path === undefined) {
@@ -196,7 +197,7 @@ var _ = Mavo.Expressions = $.Class({
 
 			this.expressions.add(new Mavo.DOMExpression({
 				node, syntax, path,
-				attribute: attribute?.name,
+				attribute: attributeName,
 				mavo: this.mavo
 			}));
 		}
@@ -271,7 +272,8 @@ var _ = Mavo.Expressions = $.Class({
 
 	static: {
 		directives: [
-			"mv-value"
+			"mv-value",
+			/^mv\-attr\-/
 		],
 
 		skip: ["mv-expressions", "mv-action"],

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -183,11 +183,11 @@ var _ = Mavo.Expressions = $.Class({
 	},
 
 	extract: function(node, attribute, path, syntax = Mavo.Expression.Syntax.default) {
-		if (attribute && _.skip.indexOf(attribute.name) > -1) {
+		if (_.skip.includes(attribute?.name)) {
 			return;
 		}
 
-		if (attribute && _.directives.indexOf(attribute.name) > -1 ||
+		if (_.directives.includes(attribute?.name) || attribute?.name?.startsWith("mv-attr-") ||
 		    syntax !== Mavo.Expression.Syntax.ESCAPE && syntax.test(attribute? attribute.value : node.textContent)
 		) {
 			if (path === undefined) {
@@ -228,7 +228,7 @@ var _ = Mavo.Expressions = $.Class({
 				..._.skip,
 
 				// Locally ignored attributes (for this element)
-				node.getAttribute("mv-expressions-ignore")?.trim().split(/\s*,\s*/) ?? []
+				...(node.getAttribute("mv-expressions-ignore")?.trim().split(/\s*,\s*/) ?? [])
 			]);
 			let specifiedAttributes = new Set(node.getAttributeNames());
 
@@ -237,8 +237,7 @@ var _ = Mavo.Expressions = $.Class({
 				if (ignoredAttributes.has(name)) {
 					specifiedAttributes.delete(name);
 				}
-
-				if (name.startsWith("mv-attr-")) {
+				else if (name.startsWith("mv-attr-")) {
 					// If mv-attr-foo is present, ignore foo
 					let plainName = name.replace("mv-attr-", "");
 					specifiedAttributes.delete(plainName);

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -223,16 +223,18 @@ var _ = Mavo.Expressions = $.Class({
 				path = [];
 			}
 
-			let ignore;
-			if (node.hasAttribute("mv-expressions-ignore")) {
-				ignore = new Set(node.getAttribute("mv-expressions-ignore").trim().split(/\s*,\s*/));
-			}
+			let ignoredAttributes = new Set([
+				// Globally ignored attributes (for all elements)
+				..._.skip,
 
+				// Locally ignored attributes (for this element)
+				node.getAttribute("mv-expressions-ignore")?.trim().split(/\s*,\s*/) ?? []
+			]);
 			let specifiedAttributes = new Set(node.getAttributeNames());
 
 			// Remove ignored attributes
 			for (let name of specifiedAttributes) {
-				if (ignore.has(name)) {
+				if (ignoredAttributes.has(name)) {
 					specifiedAttributes.delete(name);
 				}
 

--- a/src/util.js
+++ b/src/util.js
@@ -433,9 +433,9 @@ var _ = $.extend(Mavo, {
 	// Fixes the case of attributes that are not all lowercase
 	// Especially useful for SVG attributes
 	// https://html.spec.whatwg.org/multipage/parsing.html#adjust-svg-attributes
-	getProperCasing: (element, attribute) => {
-		let doc = new DOMParser().parseFromString(`<${element} ${attribute}=""></${element}>`, "text/html");
-		return doc.body.firstElementChild.attributes[0].name;
+	getProperCasing: (element, attribute, root = "svg") => {
+		let doc = new DOMParser().parseFromString(`<${root}><${element} ${attribute}=""></${element}></${root}>`, "text/html");
+		return doc.body.firstElementChild.firstElementChild.attributes[0].name;
 	},
 
 	/**

--- a/src/util.js
+++ b/src/util.js
@@ -430,14 +430,9 @@ var _ = $.extend(Mavo, {
 		return element.getAttributeNames().filter(name => regex.test(name));
 	},
 
-	// {
-	// 	"svg": {
-	// 		"viewbox": "viewBox", // all-lowercase to proper casing
-	//		...
-	// 	},
-	//	"math": { ... }
-	// }
-	properlyCasedAttributesCache: {}, // We need this to cache the results of the intense parsing operation in the following utility function
+	// We need this to cache the results of the intense parsing operation in the following utility function
+	// E.g., { "svg": { "viewbox": "viewBox", ... }, "math": { ... } }
+	properlyCasedAttributesCache: {},
 
 	// Fixes the case of attributes that are not all-lowercase
 	// Especially useful for SVG attributes

--- a/src/util.js
+++ b/src/util.js
@@ -438,7 +438,7 @@ var _ = $.extend(Mavo, {
 	// Especially useful for SVG attributes
 	// https://html.spec.whatwg.org/multipage/parsing.html#adjust-svg-attributes
 	getProperAttributeCase (element, attribute) {
-		const roots = "svg, math"; // Potential root elements
+		const roots = "svg, math, :root"; // Potential root elements
 
 		const root = element.closest(roots).tagName;
 

--- a/src/util.js
+++ b/src/util.js
@@ -430,6 +430,19 @@ var _ = $.extend(Mavo, {
 		return element.getAttributeNames().filter(name => regex.test(name));
 	},
 
+	SVGAttributes: [
+		"preserveAspectRatio", "primitiveUnits", "refX", "refY", "repeatCount", "repeatDur", "requiredExtensions",
+		"requiredFeatures", "specularConstant", "specularExponent", "spreadMethod", "startOffset", "stdDeviation",
+		"stitchTiles", "surfaceScale", "systemLanguage", "tableValues", "targetX", "targetY", "textLength", "viewBox",
+		"viewTarget", "xChannelSelector", "yChannelSelector", "zoomAndPan"
+	],
+
+	// Fixes the case of SVG attributes that are not all lowercase
+	// https://html.spec.whatwg.org/multipage/parsing.html#adjust-svg-attributes
+	adjustSVGAttribute: (attribute) => {
+		return _.SVGAttributes.find(attr => attr.toLowerCase() === attribute) || attribute;
+	},
+
 	/**
 	 *  Set/get a property or an attribute?
 	 * @return {Boolean} true to use a property, false to use the attribute

--- a/src/util.js
+++ b/src/util.js
@@ -442,7 +442,7 @@ var _ = $.extend(Mavo, {
 	// Fixes the case of attributes that are not all lowercase
 	// Especially useful for SVG attributes
 	// https://html.spec.whatwg.org/multipage/parsing.html#adjust-svg-attributes
-	getProperCasing (element, attribute, root = "svg") {
+	getProperAttributeCase (element, attribute, root = "svg") {
 		_.properlyCasedAttributesCache[root] ??= {};
 
 		let attr = _.properlyCasedAttributesCache[root][attribute];

--- a/src/util.js
+++ b/src/util.js
@@ -430,12 +430,32 @@ var _ = $.extend(Mavo, {
 		return element.getAttributeNames().filter(name => regex.test(name));
 	},
 
+	// {
+	// 	"svg": {
+	// 		"viewbox": "viewBox", // all-lowercase to proper casing
+	//		...
+	// 	},
+	//	"math": { ... }
+	// }
+	properlyCasedAttributesCache: {}, // We need this to cache the results of the intense parsing operation in the following utility function
+
 	// Fixes the case of attributes that are not all lowercase
 	// Especially useful for SVG attributes
 	// https://html.spec.whatwg.org/multipage/parsing.html#adjust-svg-attributes
-	getProperCasing: (element, attribute, root = "svg") => {
+	getProperCasing (element, attribute, root = "svg") {
+		_.properlyCasedAttributesCache[root] ??= {};
+
+		let attr = _.properlyCasedAttributesCache[root][attribute];
+		if (attr) {
+			return attr;
+		}
+
 		let doc = new DOMParser().parseFromString(`<${root}><${element} ${attribute}=""></${element}></${root}>`, "text/html");
-		return doc.body.firstElementChild.firstElementChild.attributes[0].name;
+		attr = doc.body.firstElementChild.firstElementChild.attributes[0].name;
+
+		_.properlyCasedAttributesCache[root][attribute] = attr;
+
+		return attr;
 	},
 
 	/**

--- a/src/util.js
+++ b/src/util.js
@@ -439,10 +439,14 @@ var _ = $.extend(Mavo, {
 	// }
 	properlyCasedAttributesCache: {}, // We need this to cache the results of the intense parsing operation in the following utility function
 
-	// Fixes the case of attributes that are not all lowercase
+	// Fixes the case of attributes that are not all-lowercase
 	// Especially useful for SVG attributes
 	// https://html.spec.whatwg.org/multipage/parsing.html#adjust-svg-attributes
-	getProperAttributeCase (element, attribute, root = "svg") {
+	getProperAttributeCase (element, attribute) {
+		const roots = "svg, math"; // Potential root elements
+
+		const root = element.closest(roots).tagName;
+
 		_.properlyCasedAttributesCache[root] ??= {};
 
 		let attr = _.properlyCasedAttributesCache[root][attribute];
@@ -450,7 +454,9 @@ var _ = $.extend(Mavo, {
 			return attr;
 		}
 
-		let doc = new DOMParser().parseFromString(`<${root}><${element} ${attribute}=""></${element}></${root}>`, "text/html");
+		const tag = element.tagName;
+
+		let doc = new DOMParser().parseFromString(`<${root}><${tag} ${attribute}=""></${tag}></${root}>`, "text/html");
 		attr = doc.body.firstElementChild.firstElementChild.attributes[0].name;
 
 		_.properlyCasedAttributesCache[root][attribute] = attr;

--- a/src/util.js
+++ b/src/util.js
@@ -430,17 +430,12 @@ var _ = $.extend(Mavo, {
 		return element.getAttributeNames().filter(name => regex.test(name));
 	},
 
-	SVGAttributes: [
-		"preserveAspectRatio", "primitiveUnits", "refX", "refY", "repeatCount", "repeatDur", "requiredExtensions",
-		"requiredFeatures", "specularConstant", "specularExponent", "spreadMethod", "startOffset", "stdDeviation",
-		"stitchTiles", "surfaceScale", "systemLanguage", "tableValues", "targetX", "targetY", "textLength", "viewBox",
-		"viewTarget", "xChannelSelector", "yChannelSelector", "zoomAndPan"
-	],
-
-	// Fixes the case of SVG attributes that are not all lowercase
+	// Fixes the case of attributes that are not all lowercase
+	// Especially useful for SVG attributes
 	// https://html.spec.whatwg.org/multipage/parsing.html#adjust-svg-attributes
-	adjustSVGAttribute: (attribute) => {
-		return _.SVGAttributes.find(attr => attr.toLowerCase() === attribute) || attribute;
+	getProperCasing: (element, attribute) => {
+		let doc = new DOMParser().parseFromString(`<${element} ${attribute}=""></${element}>`, "text/html");
+		return doc.body.firstElementChild.attributes[0].name;
 	},
 
 	/**


### PR DESCRIPTION
Closes #475.

I believe this feature is a nice to have in the upcoming release. I tested it on several examples, including [SVG Path Builder](https://mavo.io/demos/svgpath/). It looks like it's working. :)

I liked the idea of using the `mv-attr-*` family of attributes for the feature, so I went that way.

Since I'm not 100% sure that I do everything correctly, let's consider this PR as the first step. :)