### PR TITLE
Negative inputs to `duration` now produce negative time outputs

### DIFF
--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -234,6 +234,10 @@ _.duration = $.extend(function (ms, terms) {
 	// TODO unify code for specific unit with code for auto units to reduce repetition
 	// TODO allow multiple units, e.g. ["days", "hours"]
 	// TODO allow combining term # and units, e.g. start: days, terms: 2
+	
+	let negativeMultiplier = ms < 0 ? -1 : 1; // a multiplier to convert result to negative if needed
+	ms = Math.abs(ms); // negative works same way as positive does, just adding negative sign in the front
+
 	if (terms && isNaN(terms)) {
 		// Specific term specified
 		let unitSingular = terms != "ms" ? terms.replace(/s?$/, "") : terms;
@@ -245,17 +249,16 @@ _.duration = $.extend(function (ms, terms) {
 
 		let n = Math.floor(ms / s[unitPlural] / 1000);
 		let unitProperPlurality = n === 1 && unitPlural !== "ms" ? unitSingular : unitPlural;
-		return n + " " + _.phrase.call(this, unitProperPlurality);
+		return negativeMultiplier * n + " " + _.phrase.call(this, unitProperPlurality);
 	}
-	else if (ms === 0 || terms === undefined) {
+	else if (ms == 0 || terms === undefined) {
 		terms = 1;
 	}
 
-	let negativeMultiplier = ms < 0 ? -1 : 1; // a multiplier to convert to negative if needed
-	let timeLeft = Math.abs(ms);
+	let timeLeft = ms;
 	let ret = [];
 
-	if (ms === 0) {
+	if (ms == 0) {
 		ret = ["0 ms"];
 	}
 	else {

--- a/src/functions.date.js
+++ b/src/functions.date.js
@@ -251,10 +251,11 @@ _.duration = $.extend(function (ms, terms) {
 		terms = 1;
 	}
 
-	let timeLeft = ms || 0;
+	let negativeMultiplier = ms < 0 ? -1 : 1; // a multiplier to convert to negative if needed
+	let timeLeft = Math.abs(ms);
 	let ret = [];
 
-	if (ms < 1) {
+	if (ms === 0) {
 		ret = ["0 ms"];
 	}
 	else {
@@ -269,7 +270,7 @@ _.duration = $.extend(function (ms, terms) {
 
 			if (unitValue > 0 && ret.length < terms) {
 				let unitProperPlurality = unitValue === 1 && unit !== "ms" ? unit.slice(0, -1) : unit;
-				ret.push(unitValue + " " + _.phrase.call(this, unitProperPlurality));
+				ret.push(negativeMultiplier * unitValue + " " + _.phrase.call(this, unitProperPlurality));
 			}
 			else if (ret.length > 0) {
 				// Discard any further terms to avoid non-continous terms like e.g. "1 month, 10 ms"

--- a/src/primitive.js
+++ b/src/primitive.js
@@ -162,7 +162,7 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 		let editor = this.editor || this.originalEditor;
 
 		if (editor) {
-			if (editor.matches(Mavo.selectors.formControl)) {
+			if (_.isFormControl(editor)) {
 				return _.getValue(editor, {datatype: this.datatype});
 			}
 
@@ -181,7 +181,7 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 		}
 
 		if (this.editor) {
-			if (this.editor.matches(Mavo.selectors.formControl)) {
+			if (_.isFormControl(this.editor)) {
 				if (this.editor.matches("select")) {
 					let text = [...this.editor.options].find(o => o.value == value)?.textContent;
 
@@ -1180,6 +1180,10 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 		}
 
 		return value;
+	}
+
+	static isFormControl(element) {
+		return element.matches(Mavo.selectors.formControl) || element.matches(`[mv-edit-as="formControl"]`);
 	}
 };
 

--- a/src/primitive.js
+++ b/src/primitive.js
@@ -609,7 +609,7 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 						evt.preventDefault();
 					}
 				}
-				else if (evt.key == "Backspace" && (this.empty || evt[Mavo.superKey])) {
+				else if (evt.key == "Backspace" && this.empty) {
 					// Focus on sibling afterwards
 					let sibling = this.getCousin(1) || this.getCousin(-1);
 


### PR DESCRIPTION
Solves the main issue agreed on: https://github.com/mavoweb/mavo/issues/925
For 0 input, still returns `0 ms`.