### PR TITLE
Make mv-options work with expressions, fixes #777

### DIFF
--- a/src/primitive.js
+++ b/src/primitive.js
@@ -1316,6 +1316,9 @@ Mavo.observe({id: "primitive"}, function({node, type, attribute, record, element
 		else if (attribute === "mv-options") {
 			node.updateOptions();
 
+			let option = node.options.get(node.value) ?? node.options.keys().next().value;
+			node.setValue(option, {silent: true});
+
 			if (node.editor) {
 				node.generateDefaultEditor();
 			}


### PR DESCRIPTION
I thought it would be nice if such an awesome feature like `mv-options` would work with expressions correctly in the upcoming release. :)