### PR TITLE
Create getVariables function; addresses #975

### DIFF
--- a/src/mavoscript.js
+++ b/src/mavoscript.js
@@ -541,12 +541,12 @@ var _ = Mavo.Script = {
 			case "Literal":
 				return [];
 			case "Identifier":
-				// const isGlobal = !!globalThis[ast.name];
-				// return isGlobal? [] : [ast];	
-				return [ast];	
+				const isGlobal = !!globalThis[ast.name];
+				return isGlobal? [] : [ast];
 			case "UnaryExpression":
 				return _.getVariables(ast.argument);
 			case "BinaryExpression":
+				// handles group(key: value)
 				if (ast.operator === ':') {
 					return _.getVariables(ast.right);
 				}
@@ -555,6 +555,7 @@ var _ = Mavo.Script = {
 				return [ast.left, ast.right].flatMap(_.getVariables);
 			case "CallExpression":
 				let toExplore = [...ast.arguments];
+				// prevents adding the function name to the list of vars
 				if (ast.callee.type !== "Identifier") {
 					toExplore = [ast.callee].concat(toExplore);
 				}
@@ -567,6 +568,7 @@ var _ = Mavo.Script = {
 				return [ast.test, ast.consequent, ast.alternate].flatMap(_.getVariables);
 			case "MemberExpression":
 				const children = _.getVariables(ast.object);
+				// If the object is also a member expression, return this one (the top most one)
 				if (children[0] === ast.object) {
 					return [ast];
 				}


### PR DESCRIPTION
_Draft PR_

## Summary
- Implements a draft version of the function `getVariables`, which lies in `Mavoscript.js`, meaning it can be called by `Mavo.Script.getVariables(ast)`
- Walks an AST and returns a list of all variables used (including duplicates)
- Will help address #967 

## Work still needed
- address `where` clauses: they're hard to address because for an expression like `count(blog.post where cat in category)`, the function would attempt to return `cat` in the list of variables even though it shouldn't
- address js builtins, e.g. `Array.isArray`: you can see in this PR that there's two lines commented out in the `case: "Identifier"`. That's because it doesn't work when a Mavo-evaluated variable gets added to the global scope, and thus `globalThis[variableName]` will be defined (this can be easier discussed offline because it's pretty complicated)

## Testing
- test cases coming soon in a PR; they were scraped from Mavo sites, and the data can be found [here](https://coda.io/d/Mavo-research_d8ZCqXVfZJ4/JSONs_suO7x#_luK1O)