### PR TITLE
Better url()

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -176,7 +176,7 @@ let _ = Mavo.Functions = {
 
 
 				if (index > -1) {
-					let ret = path[index + 1];
+					let ret = path[(index + 1) % path.length]; // Why “% path.length”? To handle cases like “/foo” where foo is equal to "".
 
 					if (ret) {
 						ret = decodeURIComponent(ret);

--- a/src/functions.js
+++ b/src/functions.js
@@ -176,7 +176,7 @@ let _ = Mavo.Functions = {
 
 
 				if (index > -1) {
-					let ret = path[(index + 1) % path.length]; // Why “% path.length”? To handle cases like “/foo” where foo is equal to "".
+					let ret = path[index + 1] ?? "";
 
 					if (ret) {
 						ret = decodeURIComponent(ret);

--- a/src/functions.js
+++ b/src/functions.js
@@ -129,8 +129,8 @@ let _ = Mavo.Functions = {
 	/**
 	 * Get the page URL (if called with no params), or a parameter from it.
 	 * @param {string} id Parameter name
-	 * @param {string | URL} [url] URL to get parameter from. Defaults to current page URL
 	 * @param {object} [...options] One or more options objects
+	 * @param {string | URL} [options.url] URL to get parameter from. Defaults to current page URL
 	 * @param { "query" | "path" } [options.type] Type of parameter to get.
 	 * 		"query" for query string type URLs (?foo=value)
 	 * 		"path" for path type URLs (/foo/value)
@@ -139,7 +139,7 @@ let _ = Mavo.Functions = {
 	 * @param {boolean} [options.multiple=false] Whether to return multiple values if there are multiple parameters with the same name
 	 * @returns {string | null}
 	 */
-	url: (id, url = location, ...options) => {
+	url: (id, ...options) => {
 		if (id === undefined) {
 			// url() with no arguments is just an alias for location.href
 			return location.href;
@@ -147,7 +147,7 @@ let _ = Mavo.Functions = {
 
 		// Resolve options
 		options = Object.assign({}, ...options);
-		let { type, case_sensitive, multiple} = options;
+		let { url = location, type, case_sensitive, multiple } = options;
 
 		if (id) {
 			// Why not Mavo.base as the 2nd arg? We want a URL that will not have a path or query string of its own


### PR DESCRIPTION
See https://github.com/mavoweb/mavo/pull/985/files#r1371833984

- Add options (type, case_sensitive, multiple). Note the design with the multiple options objects allows calling it without `group()`, like `url(foo, bar, case_sensitive: true, multiple: true, type: 'path')`
- Made matching case insensitive by default
- Do not strip non-ASCII chars, just escape those that you need to escape (i18n yo)
- Refactor

Has not been tested, @DmitrySharabin you need to run it (and check the tests) before merging! Feel free to make any edits you want.