### PR TITLE
Ignore un-supported events that backend services might send

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -193,12 +193,7 @@ var _ = Mavo.Backend = class Backend extends EventTarget {
 					}
 
 					addEventListener("message", evt => {
-						if (evt.source === this.authPopup) {
-							if (!evt.data.backend) {
-								// Ignore un-supported events that backend services might send, e.g., messages from Yandex metrics.
-								return;
-							}
-
+						if (evt.source === this.authPopup && evt.data.backend) {
 							if (evt.data.backend == this.id) {
 								this.accessToken = localStorage[`mavo:${id}token`] = evt.data.token;
 							}

--- a/src/backend.js
+++ b/src/backend.js
@@ -194,6 +194,11 @@ var _ = Mavo.Backend = class Backend extends EventTarget {
 
 					addEventListener("message", evt => {
 						if (evt.source === this.authPopup) {
+							if (!evt.data.backend) {
+								// Ignore un-supported events that backend services might send, e.g., messages from Yandex metrics.
+								return;
+							}
+
 							if (evt.data.backend == this.id) {
 								this.accessToken = localStorage[`mavo:${id}token`] = evt.data.token;
 							}


### PR DESCRIPTION
Working on [the new Yandex Disk backend](https://github.com/DmitrySharabin/mavo-yandex), I noticed that it sends an extra message event to the `authPopup` window while authenticating the user. Yandex Metrics sends this message. The event doesn't contain the `backend` field in the payload, neither does it contain `accessToken` and breaks the login flow since we [`reject(Error("Authentication error"))`](https://github.com/mavoweb/mavo/blob/cf64cf58f66fa7553a3c9829153fc5724416bafa/src/backend.js#L201-L203) in such cases.

Let's ignore all `message` events that don't serve the authentication purpose.