### PR TITLE
Disable auto-saving before rendering data only

### DIFF
--- a/src/mavo.js
+++ b/src/mavo.js
@@ -135,7 +135,7 @@ let _ = self.Mavo = $.Class(class Mavo {
 		$.bind(this.element, "mv-login.mavo", evt => {
 			if (evt.backend == (this.source || this.storage)) {
 				// If last time we rendered we got nothing, maybe now we'll have better luck?
-				if (this.inProgress !== "loading" && !this.root.data && !this.unsavedChanges) {
+				if (!this.root.data && !this.unsavedChanges) {
 					this.load();
 				}
 			}
@@ -546,9 +546,6 @@ let _ = self.Mavo = $.Class(class Mavo {
 			return;
 		}
 
-		let autoSaveState = this.autoSave;
-		this.autoSave = false;
-
 		if (data === undefined) {
 			this.inProgress = "loading";
 
@@ -588,13 +585,17 @@ let _ = self.Mavo = $.Class(class Mavo {
 			this.inProgress = false;
 		}
 
+		let autoSaveState = this.autoSave;
+		this.autoSave = false;
+
 		this.render(data);
+
+		this.autoSave = autoSaveState;
 
 		await Mavo.defer();
 
 		this.dataLoaded.resolve();
 		this.element.dispatchEvent(new CustomEvent("mv-load", {detail: backend, bubbles: true}));
-		this.autoSave = autoSaveState;
 	}
 
 	async store () {


### PR DESCRIPTION
It seems to me that the only part of the `load()` method code that needs to be executed with the auto-saving disabled is `render()`. Previously, we dropped the `autoSave` flag a bit too early, which might lead to undesired consequences if some of the asynchronous events occur. This patch fixes it (as our tests and my experiments show).

- Fixes #994
- The previous patch for #910 is not needed anymore since we solved the general issue