### PR TITLE
Preserve the original editor observer

### DIFF
--- a/src/primitive.js
+++ b/src/primitive.js
@@ -426,7 +426,14 @@ var _ = Mavo.Primitive = class Primitive extends Mavo.Node {
 					}
 
 					for (let primitive of nodes) {
-						primitive.originalEditorUpdated({force: true});
+						if (primitive.defaultSource == "editor") {
+							primitive.default = this.originalEditor.value;
+						}
+
+						if (primitive.editor) {
+							primitive.editor = this.originalEditor.cloneNode(true);
+						}
+
 						primitive.setValue(primitive.value, {force: true, silent: true});
 					}
 				});


### PR DESCRIPTION
Fixes regression #996.

The main issue is that we lose the original editor observer when we force the original editor update, so the changes are not picked up when the original editor is updated via an expression.