### PR TITLE
Correctly handle <option selected>

### DIFF
--- a/src/elements.js
+++ b/src/elements.js
@@ -253,6 +253,17 @@ _.register({
 		default: true
 	},
 
+	"option[selected]": {
+		selector: "select option[selected]",
+		attribute: "selected",
+		datatype: "boolean",
+		setValue: (element, value) => {
+			element.selected = value;
+			element.closest("select")?.dispatchEvent(new Event("change"));
+		},
+		getValue: element => element.selected
+	},
+
 	"textarea": {
 		extend: "formControl",
 		selector: "textarea",


### PR DESCRIPTION
Fixes #702 (it also might fix some other issue concerning dynamic `<select>`s; I will check).

As [we know from MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#selected), the `selected` boolean attribute indicates that the option is _initially_ selected ([when the page first loads](https://arc.net/l/quote/eehrfvfq)). It means that if we try to change the selected option programmatically (via an expression) after the page is loaded, we'll fail. This PR should solve the issue by telling the corresponding `<select>` that one of its `<option>`s became selected via the `selected` attribute. This will allow Mavo to pick up updates on the corresponding properties.