### PR TITLE
Ignore clicks on elements inside Mavo controls when triggering actions

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -4,11 +4,16 @@ Mavo.attributes.push("mv-action");
 
 let _ = Mavo.Actions = {
 	listener: evt => {
+		// Clicking elements inside these elements should be ignored
+		// if the target element is closer to them than to the [mv-action] element
+		let controlSelector = ".mv-ui, .mv-editor, .mv-popup, .mv-drag-handle";
+
 		let tag = evt.type === "submit"? "form" : ":not(form)";
 		let element = evt.target.closest(tag + "[mv-action]");
+		let control = evt.target.closest(tag + controlSelector);
 
-		if (!element) {
-			return; // Not an action
+		if (!element || control && !control.contains(element)) {
+			return; // Not an action or the click should be ignored
 		}
 
 		let node = Mavo.Node.get(element);

--- a/src/actions.js
+++ b/src/actions.js
@@ -10,7 +10,7 @@ let _ = Mavo.Actions = {
 
 		let tag = evt.type === "submit"? "form" : ":not(form)";
 		let element = evt.target.closest(tag + "[mv-action]");
-		let control = evt.target.closest(tag + controlSelector);
+		let control = evt.target.closest(tag + `:is(${ controlSelector })`);
 
 		if (!element || control && !control.contains(element)) {
 			return; // Not an action or the click should be ignored

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,7 +6,10 @@ let _ = Mavo.Actions = {
 	listener: evt => {
 		// Clicking elements inside these elements should be ignored
 		// if the target element is closer to them than to the [mv-action] element
-		let controlSelector = ".mv-ui, .mv-editor, .mv-popup, .mv-drag-handle";
+		let controlSelector = `
+			.mv-ui, .mv-editor, .mv-popup, .mv-drag-handle,
+			button, label, input, output, select, textarea, meter, progress
+		`;
 
 		let tag = evt.type === "submit"? "form" : ":not(form)";
 		let element = evt.target.closest(tag + "[mv-action]");


### PR DESCRIPTION
Partially addresses #1036.

Cases, when one clicks a form control inside an `[mv-action]` element, are not addressed by this PR. But I still think this PR is an improvement on the current state.